### PR TITLE
Replace exit(134) on socket errors with exception

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -102,19 +102,13 @@ namespace hegel::impl::socket {
     }
 } // namespace hegel::impl::socket
 
-// =============================================================================
-// Constants
-// =============================================================================
-inline constexpr int ASSERTION_FAILURE_EXIT_CODE = 134;
-
 namespace hegel::internal {
     nlohmann::json communicate_with_socket(const nlohmann::json& schema) {
         auto* conn = impl::socket::get_embedded_connection();
         uint32_t data_channel = impl::socket::get_embedded_data_channel();
 
         if (!conn) {
-            std::cerr << "hegel: no connection set\n";
-            std::exit(ASSERTION_FAILURE_EXIT_CODE);
+            throw std::runtime_error("hegel: no connection set");
         }
 
         // Build generate request as CBOR


### PR DESCRIPTION
## Summary

Remove legacy behaviour where connection/socket errors cause `std::exit(134)`. Instead, throw `std::runtime_error` consistent with how other errors in the codebase are handled.

This was a holdover from a previous design where exit code 134 (SIGABRT) was used to signal socket errors. It's no longer relevant — connection errors should propagate normally.

## Changes

- Remove `ASSERTION_FAILURE_EXIT_CODE` constant from `src/socket.cpp`
- Replace `std::exit(ASSERTION_FAILURE_EXIT_CODE)` with `throw std::runtime_error(...)` in `communicate_with_socket()`