### PR TITLE
Fix release workflow permissions and skip logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,15 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - name: Check all required workflows passed
+      - name: Check release preconditions
+        id: check
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -30,13 +32,11 @@ jobs:
             --paginate --jq '.check_runs[] | select(.name != "release") | .conclusion')
           if echo "$CHECKS" | grep -qvE '^success$'; then
             echo "Not all checks passed yet, skipping release"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-      - name: Check for RELEASE.md
-        id: check
-        run: |
           if [ ! -f RELEASE.md ]; then
+            echo "No RELEASE.md found, skipping release"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -48,11 +48,10 @@ jobs:
           app-id: ${{ vars.HEGEL_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEGEL_RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Re-checkout with app token
+      - name: Re-checkout with app token # zizmor: ignore[artipacked]
         if: steps.check.outputs.skip != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Release


### PR DESCRIPTION
## Summary

Ports release workflow fixes from hegel-core (antithesishq/hegel-core#29, antithesishq/hegel-core#30):

- Add `checks: read` permission so the check-runs API call works
- Merge "check all workflows passed" and "check for RELEASE.md" into a single precondition step with proper `skip` output for both paths
- Remove `persist-credentials: false` from the app token re-checkout step — the token must persist for the release script to push tags/commits
- Add `# zizmor: ignore[artipacked]` to suppress the warning on the intentionally-persisted credentials

## Test plan

- [ ] Verify release workflow no longer fails with permissions errors
- [ ] Verify release skips cleanly when not all checks have passed
- [ ] Verify release skips cleanly when no RELEASE.md exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)