### PR TITLE
Manage hegel binary via pinned .hegel/venv

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -59,16 +59,16 @@ def set_version(cmake_file: Path, new_version: str) -> None:
 
 
 def pin_hegel_version(hegel_cpp: Path) -> None:
-    """Pin HEGEL_VERSION to the current HEAD of hegel-core main."""
-    sha = subprocess.check_output(
-        ["gh", "api", "repos/antithesishq/hegel-core/commits/main", "--jq", ".sha"],
+    """Pin HEGEL_VERSION to the latest hegel-core release tag."""
+    tag = subprocess.check_output(
+        ["gh", "api", "repos/antithesishq/hegel-core/releases/latest", "--jq", ".tag_name"],
         text=True,
     ).strip()
 
     text = hegel_cpp.read_text()
     new_text = re.sub(
         r'^( *static const std::string HEGEL_VERSION =)\s*".*";',
-        f'\\1\n        "{sha}";',
+        f'\\1\n        "{tag}";',
         text,
         count=1,
         flags=re.MULTILINE,

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -58,24 +58,6 @@ def set_version(cmake_file: Path, new_version: str) -> None:
     cmake_file.write_text(new_text)
 
 
-def pin_hegel_version(hegel_cpp: Path) -> None:
-    """Pin HEGEL_VERSION to the latest hegel-core release tag."""
-    tag = subprocess.check_output(
-        ["gh", "api", "repos/antithesishq/hegel-core/releases/latest", "--jq", ".tag_name"],
-        text=True,
-    ).strip()
-
-    text = hegel_cpp.read_text()
-    new_text = re.sub(
-        r'^( *static const std::string HEGEL_VERSION =)\s*".*";',
-        f'\\1 "{tag}";',
-        text,
-        count=1,
-        flags=re.MULTILINE,
-    )
-    hegel_cpp.write_text(new_text)
-
-
 def add_changelog(path: Path, *, version: str, content: str) -> None:
     date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     entry = f"## {version} - {date}\n\n{content}"
@@ -140,13 +122,12 @@ def release() -> None:
     new_version = bump_version(m.group(1), release_type)
 
     set_version(cmake_file, new_version)
-    pin_hegel_version(ROOT / "src" / "hegel.cpp")
 
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
     git("config", "user.name", "hegel-release[bot]", cwd=ROOT)
     git("config", "user.email", "noreply@github.com", cwd=ROOT)
-    git("add", "CMakeLists.txt", "src/hegel.cpp", "CHANGELOG.md", cwd=ROOT)
+    git("add", "CMakeLists.txt", "CHANGELOG.md", cwd=ROOT)
     git("rm", "RELEASE.md", cwd=ROOT)
     git(
         "commit",

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -58,22 +58,22 @@ def set_version(cmake_file: Path, new_version: str) -> None:
     cmake_file.write_text(new_text)
 
 
-def pin_hegel_version(cmake_file: Path) -> None:
+def pin_hegel_version(hegel_cpp: Path) -> None:
     """Pin HEGEL_VERSION to the current HEAD of hegel-core main."""
     sha = subprocess.check_output(
         ["gh", "api", "repos/antithesishq/hegel-core/commits/main", "--jq", ".sha"],
         text=True,
     ).strip()
 
-    text = cmake_file.read_text()
+    text = hegel_cpp.read_text()
     new_text = re.sub(
-        r'^set\(HEGEL_VERSION ".*"\)',
-        f'set(HEGEL_VERSION "{sha}")',
+        r'^( *static const std::string HEGEL_VERSION =)\s*".*";',
+        f'\\1\n        "{sha}";',
         text,
         count=1,
         flags=re.MULTILINE,
     )
-    cmake_file.write_text(new_text)
+    hegel_cpp.write_text(new_text)
 
 
 def add_changelog(path: Path, *, version: str, content: str) -> None:
@@ -140,13 +140,13 @@ def release() -> None:
     new_version = bump_version(m.group(1), release_type)
 
     set_version(cmake_file, new_version)
-    pin_hegel_version(cmake_file)
+    pin_hegel_version(ROOT / "src" / "hegel.cpp")
 
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
     git("config", "user.name", "hegel-release[bot]", cwd=ROOT)
     git("config", "user.email", "noreply@github.com", cwd=ROOT)
-    git("add", "CMakeLists.txt", "CHANGELOG.md", cwd=ROOT)
+    git("add", "CMakeLists.txt", "src/hegel.cpp", "CHANGELOG.md", cwd=ROOT)
     git("rm", "RELEASE.md", cwd=ROOT)
     git(
         "commit",

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -58,6 +58,24 @@ def set_version(cmake_file: Path, new_version: str) -> None:
     cmake_file.write_text(new_text)
 
 
+def pin_hegel_version(cmake_file: Path) -> None:
+    """Pin HEGEL_VERSION to the current HEAD of hegel-core main."""
+    sha = subprocess.check_output(
+        ["gh", "api", "repos/antithesishq/hegel-core/commits/main", "--jq", ".sha"],
+        text=True,
+    ).strip()
+
+    text = cmake_file.read_text()
+    new_text = re.sub(
+        r'^set\(HEGEL_VERSION ".*"\)',
+        f'set(HEGEL_VERSION "{sha}")',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    cmake_file.write_text(new_text)
+
+
 def add_changelog(path: Path, *, version: str, content: str) -> None:
     date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     entry = f"## {version} - {date}\n\n{content}"
@@ -122,6 +140,7 @@ def release() -> None:
     new_version = bump_version(m.group(1), release_type)
 
     set_version(cmake_file, new_version)
+    pin_hegel_version(cmake_file)
 
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -68,7 +68,7 @@ def pin_hegel_version(hegel_cpp: Path) -> None:
     text = hegel_cpp.read_text()
     new_text = re.sub(
         r'^( *static const std::string HEGEL_VERSION =)\s*".*";',
-        f'\\1\n        "{tag}";',
+        f'\\1 "{tag}";',
         text,
         count=1,
         flags=re.MULTILINE,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -122,7 +122,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -166,7 +166,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -201,7 +201,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
       - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -229,7 +229,7 @@ jobs:
 
       - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
       - name: Install Doxygen
         run: sudo apt-get update && sudo apt-get install -y doxygen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Run property tests
         env:
-          HEGEL_CMD: hegel
+          HEGEL_SERVER_COMMAND: hegel
         run: ctest --test-dir build --output-on-failure -j$(nproc)
 
   conformance:
@@ -185,7 +185,7 @@ jobs:
       - name: Run conformance tests
         timeout-minutes: 10
         env:
-          HEGEL_CMD: hegel
+          HEGEL_SERVER_COMMAND: hegel
         run: |
           pip install pytest pytest-subtests
           pytest tests/conformance/test_conformance.py -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install hegel
+        run: pip install "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git"
+
       - name: Configure CMake
         env:
           CC: ${{ matrix.cc }}
@@ -146,7 +149,9 @@ jobs:
         run: cmake --build build -j$(nproc)
 
       - name: Run property tests
-        run: ctest --test-dir build/tests --output-on-failure -j$(nproc)
+        env:
+          HEGEL_CMD: hegel
+        run: ctest --test-dir build --output-on-failure -j$(nproc)
 
   conformance:
     name: conformance
@@ -182,6 +187,8 @@ jobs:
 
       - name: Run conformance tests
         timeout-minutes: 10
+        env:
+          HEGEL_CMD: hegel
         run: |
           pip install pytest pytest-subtests
           pytest tests/conformance/test_conformance.py -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: read
     steps:
@@ -64,15 +65,13 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Install hegel
-        run: pip install git+ssh://git@github.com/antithesishq/hegel.git
-
       - name: Run clang-tidy
         run: just check-tidy
 
   build-and-test:
     name: ${{ matrix.compiler }} ${{ matrix.stdlib && format('(with {0})', matrix.stdlib) || '' }} ${{ matrix.extra_label || '' }}
     runs-on: ubuntu-24.04
+    environment: ci
     permissions:
       contents: read
 
@@ -121,6 +120,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $PACKAGES
 
+      - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+
       - uses: ./.github/actions/base
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
@@ -129,9 +130,6 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
-
-      - name: Install hegel
-        run: pip install git+ssh://git@github.com/antithesishq/hegel.git
 
       - name: Configure CMake
         env:
@@ -153,6 +151,7 @@ jobs:
   conformance:
     name: conformance
     runs-on: ubuntu-24.04
+    environment: ci
     permissions:
       contents: read
     steps:
@@ -160,6 +159,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
       - uses: ./.github/actions/base
         with:
@@ -170,8 +171,8 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Install hegel
-        run: pip install git+ssh://git@github.com/antithesishq/hegel.git
+      - name: Install hegel (for conformance framework)
+        run: pip install "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git"
 
       - name: Configure CMake
         run: cmake -B build
@@ -182,12 +183,13 @@ jobs:
       - name: Run conformance tests
         timeout-minutes: 10
         run: |
-          pip install pytest
+          pip install pytest pytest-subtests
           pytest tests/conformance/test_conformance.py -v
 
   nix:
     name: nix
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: read
     steps:
@@ -213,12 +215,15 @@ jobs:
   docs:
     name: docs
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
       - uses: ./.github/actions/base
         with:
@@ -232,9 +237,6 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Install hegel
-        run: pip install git+ssh://git@github.com/antithesishq/hegel.git
-
       - name: Configure CMake
         run: cmake -B build -DHEGEL_BUILD_DOCS=ON
 
@@ -246,6 +248,7 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'antithesishq/hegel-cpp'
     needs: [lint, build-and-test, conformance, docs]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -56,7 +55,7 @@ jobs:
       - name: Run zizmor
         run: zizmor --format plain .github/
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
@@ -71,7 +70,6 @@ jobs:
   build-and-test:
     name: ${{ matrix.compiler }} ${{ matrix.stdlib && format('(with {0})', matrix.stdlib) || '' }} ${{ matrix.extra_label || '' }}
     runs-on: ubuntu-24.04
-    environment: ci
     permissions:
       contents: read
 
@@ -122,7 +120,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
@@ -156,7 +154,6 @@ jobs:
   conformance:
     name: conformance
     runs-on: ubuntu-24.04
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -167,7 +164,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 
@@ -196,14 +193,13 @@ jobs:
   nix:
     name: nix
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
       - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
@@ -222,7 +218,6 @@ jobs:
   docs:
     name: docs
     runs-on: ubuntu-latest
-    environment: ci
     permissions:
       contents: read
     steps:
@@ -232,7 +227,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
-      - uses: ./.github/actions/base
+      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
         with:
           ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Run zizmor
         run: zizmor --format plain .github/
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -120,9 +120,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -164,9 +164,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -199,9 +199,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
       - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
@@ -227,9 +227,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
 
-      - uses: ./.github/actions/base  # zizmor: ignore[secrets-outside-env]
+      - uses: ./.github/actions/base
         with:
-          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.HEGEL_DEPLOY_KEY }} # zizmor: ignore[secrets-outside-env]
 
       - name: Install Doxygen
         run: sudo apt-get update && sudo apt-get install -y doxygen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,7 +250,6 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'antithesishq/hegel-cpp'
     needs: [lint, build-and-test, conformance, docs]
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           git diff --exit-code
 
       - name: Install zizmor
-        run: pip install zizmor
+        run: pipx install zizmor==1.23.1
       - name: Run zizmor
         run: zizmor --format plain .github/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,7 @@ jobs:
         with:
           app-id: ${{ vars.HEGEL_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEGEL_RELEASE_APP_PRIVATE_KEY }}
+          repositories: hegel-cpp,hegel-core
 
       - name: Re-checkout with app token # zizmor: ignore[artipacked]
         if: steps.check.outputs.skip != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,67 +19,73 @@ endif()
 # Hegel server binary
 # =============================================================================
 #
-# Install the pinned version of hegel-core into .hegel/venv via uv.
+# If HEGEL_PATH is set (e.g. by a nix build), use it directly.
+# Otherwise install the pinned version of hegel-core into .hegel/venv via uv.
 # The version file (.hegel/venv/hegel-version) caches the installed commit
 # so subsequent configures are fast.  Requires `uv` on PATH.
 
-set(HEGEL_VERSION "6e327df2dd42553de12ace94cfbddfbbd9e4bf50")
-set(HEGEL_PYTHON_VERSION "3.13")
-
-set(HEGEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.hegel")
-set(HEGEL_VENV_DIR "${HEGEL_DIR}/venv")
-set(HEGEL_BINARY_PATH "${HEGEL_VENV_DIR}/bin/hegel")
-set(HEGEL_VERSION_FILE "${HEGEL_VENV_DIR}/hegel-version")
-
-# Check cached version
-set(HEGEL_CACHED_VERSION "")
-if(EXISTS "${HEGEL_VERSION_FILE}")
-  file(READ "${HEGEL_VERSION_FILE}" HEGEL_CACHED_VERSION)
-  string(STRIP "${HEGEL_CACHED_VERSION}" HEGEL_CACHED_VERSION)
-endif()
-
-if(HEGEL_CACHED_VERSION STREQUAL HEGEL_VERSION AND EXISTS "${HEGEL_BINARY_PATH}")
-  message(STATUS "hegel ${HEGEL_VERSION} already installed")
+if(HEGEL_PATH)
+  set(HEGEL_BINARY_PATH "${HEGEL_PATH}")
+  message(STATUS "using provided hegel: ${HEGEL_BINARY_PATH}")
 else()
-  find_program(UV_EXECUTABLE uv REQUIRED)
-  message(STATUS "using uv: ${UV_EXECUTABLE}")
+  set(HEGEL_VERSION "6e327df2dd42553de12ace94cfbddfbbd9e4bf50")
+  set(HEGEL_PYTHON_VERSION "3.13")
 
-  message(STATUS "creating venv at ${HEGEL_VENV_DIR}")
-  execute_process(
-    COMMAND ${UV_EXECUTABLE} venv --python ${HEGEL_PYTHON_VERSION} ${HEGEL_VENV_DIR}
-    RESULT_VARIABLE UV_VENV_RESULT
-  )
-  if(NOT UV_VENV_RESULT EQUAL 0)
-    message(FATAL_ERROR "failed to create venv")
+  set(HEGEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.hegel")
+  set(HEGEL_VENV_DIR "${HEGEL_DIR}/venv")
+  set(HEGEL_BINARY_PATH "${HEGEL_VENV_DIR}/bin/hegel")
+  set(HEGEL_VERSION_FILE "${HEGEL_VENV_DIR}/hegel-version")
+
+  # Check cached version
+  set(HEGEL_CACHED_VERSION "")
+  if(EXISTS "${HEGEL_VERSION_FILE}")
+    file(READ "${HEGEL_VERSION_FILE}" HEGEL_CACHED_VERSION)
+    string(STRIP "${HEGEL_CACHED_VERSION}" HEGEL_CACHED_VERSION)
   endif()
 
-  message(STATUS "installing hegel (${HEGEL_VERSION})")
-
-  # Prefer local checkout in external/hegel-core if present
-  set(HEGEL_LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/hegel-core")
-  if(EXISTS "${HEGEL_LOCAL_DIR}/pyproject.toml")
-    message(STATUS "using local hegel from ${HEGEL_LOCAL_DIR}")
-    set(HEGEL_INSTALL_SOURCE "${HEGEL_LOCAL_DIR}")
+  if(HEGEL_CACHED_VERSION STREQUAL HEGEL_VERSION AND EXISTS "${HEGEL_BINARY_PATH}")
+    message(STATUS "hegel ${HEGEL_VERSION} already installed")
   else()
-    set(HEGEL_INSTALL_SOURCE "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git@${HEGEL_VERSION}")
+    find_program(UV_EXECUTABLE uv REQUIRED)
+    message(STATUS "using uv: ${UV_EXECUTABLE}")
+
+    message(STATUS "creating venv at ${HEGEL_VENV_DIR}")
+    execute_process(
+      COMMAND ${UV_EXECUTABLE} venv --python ${HEGEL_PYTHON_VERSION} ${HEGEL_VENV_DIR}
+      RESULT_VARIABLE UV_VENV_RESULT
+    )
+    if(NOT UV_VENV_RESULT EQUAL 0)
+      message(FATAL_ERROR "failed to create venv")
+    endif()
+
+    message(STATUS "installing hegel (${HEGEL_VERSION})")
+
+    # Prefer local checkout in external/hegel-core if present
+    set(HEGEL_LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/hegel-core")
+    if(EXISTS "${HEGEL_LOCAL_DIR}/pyproject.toml")
+      message(STATUS "using local hegel from ${HEGEL_LOCAL_DIR}")
+      set(HEGEL_INSTALL_SOURCE "${HEGEL_LOCAL_DIR}")
+    else()
+      set(HEGEL_INSTALL_SOURCE "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git@${HEGEL_VERSION}")
+    endif()
+
+    execute_process(
+      COMMAND ${UV_EXECUTABLE} pip install ${HEGEL_INSTALL_SOURCE}
+              --python ${HEGEL_VENV_DIR}/bin/python
+      RESULT_VARIABLE HEGEL_INSTALL_RESULT
+    )
+    if(NOT HEGEL_INSTALL_RESULT EQUAL 0)
+      message(FATAL_ERROR "failed to install hegel")
+    endif()
+    if(NOT EXISTS "${HEGEL_BINARY_PATH}")
+      message(FATAL_ERROR "hegel not found after installation: ${HEGEL_BINARY_PATH}")
+    endif()
+
+    file(WRITE "${HEGEL_VERSION_FILE}" "${HEGEL_VERSION}")
   endif()
 
-  execute_process(
-    COMMAND ${UV_EXECUTABLE} pip install ${HEGEL_INSTALL_SOURCE}
-            --python ${HEGEL_VENV_DIR}/bin/python
-    RESULT_VARIABLE HEGEL_INSTALL_RESULT
-  )
-  if(NOT HEGEL_INSTALL_RESULT EQUAL 0)
-    message(FATAL_ERROR "failed to install hegel")
-  endif()
-  if(NOT EXISTS "${HEGEL_BINARY_PATH}")
-    message(FATAL_ERROR "hegel not found after installation: ${HEGEL_BINARY_PATH}")
-  endif()
-
-  file(WRITE "${HEGEL_VERSION_FILE}" "${HEGEL_VERSION}")
+  message(STATUS "using hegel: ${HEGEL_BINARY_PATH}")
 endif()
-
-message(STATUS "using hegel: ${HEGEL_BINARY_PATH}")
 
 # =============================================================================
 # Dependencies via FetchContent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,73 +18,11 @@ endif()
 # =============================================================================
 # Hegel server binary
 # =============================================================================
-#
-# If HEGEL_PATH is set (e.g. by a nix build), use it directly.
-# Otherwise install the pinned version of hegel-core into .hegel/venv via uv.
-# The version file (.hegel/venv/hegel-version) caches the installed commit
-# so subsequent configures are fast.  Requires `uv` on PATH.
+# If HEGEL_PATH is set (e.g. by a nix build), use it as compile-time default.
+# Otherwise the SDK auto-installs at runtime via .hegel/venv.
 
 if(HEGEL_PATH)
-  set(HEGEL_BINARY_PATH "${HEGEL_PATH}")
-  message(STATUS "using provided hegel: ${HEGEL_BINARY_PATH}")
-else()
-  set(HEGEL_VERSION "6e327df2dd42553de12ace94cfbddfbbd9e4bf50")
-  set(HEGEL_PYTHON_VERSION "3.13")
-
-  set(HEGEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.hegel")
-  set(HEGEL_VENV_DIR "${HEGEL_DIR}/venv")
-  set(HEGEL_BINARY_PATH "${HEGEL_VENV_DIR}/bin/hegel")
-  set(HEGEL_VERSION_FILE "${HEGEL_VENV_DIR}/hegel-version")
-
-  # Check cached version
-  set(HEGEL_CACHED_VERSION "")
-  if(EXISTS "${HEGEL_VERSION_FILE}")
-    file(READ "${HEGEL_VERSION_FILE}" HEGEL_CACHED_VERSION)
-    string(STRIP "${HEGEL_CACHED_VERSION}" HEGEL_CACHED_VERSION)
-  endif()
-
-  if(HEGEL_CACHED_VERSION STREQUAL HEGEL_VERSION AND EXISTS "${HEGEL_BINARY_PATH}")
-    message(STATUS "hegel ${HEGEL_VERSION} already installed")
-  else()
-    find_program(UV_EXECUTABLE uv REQUIRED)
-    message(STATUS "using uv: ${UV_EXECUTABLE}")
-
-    message(STATUS "creating venv at ${HEGEL_VENV_DIR}")
-    execute_process(
-      COMMAND ${UV_EXECUTABLE} venv --python ${HEGEL_PYTHON_VERSION} ${HEGEL_VENV_DIR}
-      RESULT_VARIABLE UV_VENV_RESULT
-    )
-    if(NOT UV_VENV_RESULT EQUAL 0)
-      message(FATAL_ERROR "failed to create venv")
-    endif()
-
-    message(STATUS "installing hegel (${HEGEL_VERSION})")
-
-    # Prefer local checkout in external/hegel-core if present
-    set(HEGEL_LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/hegel-core")
-    if(EXISTS "${HEGEL_LOCAL_DIR}/pyproject.toml")
-      message(STATUS "using local hegel from ${HEGEL_LOCAL_DIR}")
-      set(HEGEL_INSTALL_SOURCE "${HEGEL_LOCAL_DIR}")
-    else()
-      set(HEGEL_INSTALL_SOURCE "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git@${HEGEL_VERSION}")
-    endif()
-
-    execute_process(
-      COMMAND ${UV_EXECUTABLE} pip install ${HEGEL_INSTALL_SOURCE}
-              --python ${HEGEL_VENV_DIR}/bin/python
-      RESULT_VARIABLE HEGEL_INSTALL_RESULT
-    )
-    if(NOT HEGEL_INSTALL_RESULT EQUAL 0)
-      message(FATAL_ERROR "failed to install hegel")
-    endif()
-    if(NOT EXISTS "${HEGEL_BINARY_PATH}")
-      message(FATAL_ERROR "hegel not found after installation: ${HEGEL_BINARY_PATH}")
-    endif()
-
-    file(WRITE "${HEGEL_VERSION_FILE}" "${HEGEL_VERSION}")
-  endif()
-
-  message(STATUS "using hegel: ${HEGEL_BINARY_PATH}")
+  message(STATUS "using provided hegel: ${HEGEL_PATH}")
 endif()
 
 # =============================================================================
@@ -148,9 +86,9 @@ target_link_libraries(hegel
   PUBLIC reflectcpp
 )
 target_compile_features(hegel PUBLIC cxx_std_20)
-target_compile_definitions(hegel PUBLIC
-    HEGEL_DEFAULT_PATH="${HEGEL_BINARY_PATH}"
-)
+if(HEGEL_PATH)
+  target_compile_definitions(hegel PUBLIC HEGEL_DEFAULT_PATH="${HEGEL_PATH}")
+endif()
 
 # =============================================================================
 # Tests with Google Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,92 +15,68 @@ if(HEGEL_COVERAGE)
     add_link_options(--coverage)
 endif()
 
-# In order:
-# * Prefer `hegel` on PATH
-# * If not found, install hegel with uv
-#    * Prefer `uv` on PATH
-#    * If not found, install uv from installer
+# =============================================================================
+# Hegel server binary
+# =============================================================================
 #
-# All artifacts are installed to `CMAKE_BINARY_DIR/_deps/hegel`.
+# Install the pinned version of hegel-core into .hegel/venv via uv.
+# The version file (.hegel/venv/hegel-version) caches the installed commit
+# so subsequent configures are fast.  Requires `uv` on PATH.
 
+set(HEGEL_VERSION "6e327df2dd42553de12ace94cfbddfbbd9e4bf50")
 set(HEGEL_PYTHON_VERSION "3.13")
-set(HEGEL_INSTALL_DIR "${CMAKE_BINARY_DIR}/_deps/hegel")
 
-find_program(HEGEL_ON_PATH hegel)
+set(HEGEL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.hegel")
+set(HEGEL_VENV_DIR "${HEGEL_DIR}/venv")
+set(HEGEL_BINARY_PATH "${HEGEL_VENV_DIR}/bin/hegel")
+set(HEGEL_VERSION_FILE "${HEGEL_VENV_DIR}/hegel-version")
 
-if(HEGEL_ON_PATH)
-  message(STATUS "found hegel on path: ${HEGEL_ON_PATH}")
-  set(HEGEL_BINARY_PATH "${HEGEL_ON_PATH}")
+# Check cached version
+set(HEGEL_CACHED_VERSION "")
+if(EXISTS "${HEGEL_VERSION_FILE}")
+  file(READ "${HEGEL_VERSION_FILE}" HEGEL_CACHED_VERSION)
+  string(STRIP "${HEGEL_CACHED_VERSION}" HEGEL_CACHED_VERSION)
+endif()
+
+if(HEGEL_CACHED_VERSION STREQUAL HEGEL_VERSION AND EXISTS "${HEGEL_BINARY_PATH}")
+  message(STATUS "hegel ${HEGEL_VERSION} already installed")
 else()
-  set(HEGEL_VENV_DIR "${HEGEL_INSTALL_DIR}/.venv")
-  set(HEGEL_BINARY_PATH "${HEGEL_VENV_DIR}/bin/hegel")
+  find_program(UV_EXECUTABLE uv REQUIRED)
+  message(STATUS "using uv: ${UV_EXECUTABLE}")
 
-  if(EXISTS "${HEGEL_BINARY_PATH}")
-    message(STATUS "found hegel: ${HEGEL_BINARY_PATH}")
-  else()
-    find_program(UV_ON_PATH uv)
-
-    if(UV_ON_PATH)
-      message(STATUS "found uv on PATH: ${UV_ON_PATH}")
-      set(UV_EXECUTABLE "${UV_ON_PATH}")
-    else()
-      set(UV_EXECUTABLE "${HEGEL_INSTALL_DIR}/uv")
-
-      if(EXISTS "${UV_EXECUTABLE}")
-        message(STATUS "found uv: ${UV_EXECUTABLE}")
-      else()
-        message(STATUS "installing uv")
-
-        file(MAKE_DIRECTORY "${HEGEL_INSTALL_DIR}")
-
-        execute_process(
-          COMMAND sh -c "curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=${HEGEL_INSTALL_DIR} UV_NO_MODIFY_PATH=1 sh"
-          RESULT_VARIABLE UV_INSTALL_RESULT
-        )
-        if(NOT UV_INSTALL_RESULT EQUAL 0)
-          message(FATAL_ERROR "uv install script failed")
-        endif()
-        if(NOT EXISTS "${UV_EXECUTABLE}")
-          message(FATAL_ERROR "uv not found at ${UV_EXECUTABLE} after installation")
-        endif()
-      endif()
-    endif()
-
-    message(STATUS "using uv: ${UV_EXECUTABLE}")
-
-    message(STATUS "creating venv at ${HEGEL_VENV_DIR}")
-
-    execute_process(
-      COMMAND ${UV_EXECUTABLE} venv --python ${HEGEL_PYTHON_VERSION} ${HEGEL_VENV_DIR}
-      RESULT_VARIABLE UV_VENV_RESULT
-    )
-    if(NOT UV_VENV_RESULT EQUAL 0)
-      message(FATAL_ERROR "failed to create venv")
-    endif()
-
-    message(STATUS "installing hegel")
-
-    # Prefer local checkout in external/hegel if present
-    set(HEGEL_LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/hegel")
-    if(EXISTS "${HEGEL_LOCAL_DIR}/pyproject.toml")
-      message(STATUS "using local hegel from ${HEGEL_LOCAL_DIR}")
-      set(HEGEL_INSTALL_SOURCE "${HEGEL_LOCAL_DIR}")
-    else()
-      set(HEGEL_INSTALL_SOURCE "git+ssh://git@github.com/antithesishq/hegel.git")
-    endif()
-
-    execute_process(
-      COMMAND ${UV_EXECUTABLE} pip install ${HEGEL_INSTALL_SOURCE}
-              --python ${HEGEL_VENV_DIR}/bin/python
-      RESULT_VARIABLE HEGEL_INSTALL_RESULT
-    )
-    if(NOT HEGEL_INSTALL_RESULT EQUAL 0)
-      message(FATAL_ERROR "failed to install hegel")
-    endif()
-    if(NOT EXISTS "${HEGEL_BINARY_PATH}")
-      message(FATAL_ERROR "hegel not found after installation: ${HEGEL_BINARY_PATH}")
-    endif()
+  message(STATUS "creating venv at ${HEGEL_VENV_DIR}")
+  execute_process(
+    COMMAND ${UV_EXECUTABLE} venv --python ${HEGEL_PYTHON_VERSION} ${HEGEL_VENV_DIR}
+    RESULT_VARIABLE UV_VENV_RESULT
+  )
+  if(NOT UV_VENV_RESULT EQUAL 0)
+    message(FATAL_ERROR "failed to create venv")
   endif()
+
+  message(STATUS "installing hegel (${HEGEL_VERSION})")
+
+  # Prefer local checkout in external/hegel-core if present
+  set(HEGEL_LOCAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/hegel-core")
+  if(EXISTS "${HEGEL_LOCAL_DIR}/pyproject.toml")
+    message(STATUS "using local hegel from ${HEGEL_LOCAL_DIR}")
+    set(HEGEL_INSTALL_SOURCE "${HEGEL_LOCAL_DIR}")
+  else()
+    set(HEGEL_INSTALL_SOURCE "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git@${HEGEL_VERSION}")
+  endif()
+
+  execute_process(
+    COMMAND ${UV_EXECUTABLE} pip install ${HEGEL_INSTALL_SOURCE}
+            --python ${HEGEL_VENV_DIR}/bin/python
+    RESULT_VARIABLE HEGEL_INSTALL_RESULT
+  )
+  if(NOT HEGEL_INSTALL_RESULT EQUAL 0)
+    message(FATAL_ERROR "failed to install hegel")
+  endif()
+  if(NOT EXISTS "${HEGEL_BINARY_PATH}")
+    message(FATAL_ERROR "hegel not found after installation: ${HEGEL_BINARY_PATH}")
+  endif()
+
+  file(WRITE "${HEGEL_VERSION_FILE}" "${HEGEL_VERSION}")
 endif()
 
 message(STATUS "using hegel: ${HEGEL_BINARY_PATH}")

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ into it. Subsequent configures reuse the cached binary unless the pinned
 version changes.
 
 To use your own `hegel` binary instead (e.g. a local development build), set
-the `HEGEL_CMD` environment variable:
+the `HEGEL_SERVER_COMMAND` environment variable:
 
 ```bash
-export HEGEL_CMD=/path/to/hegel
+export HEGEL_SERVER_COMMAND=/path/to/hegel
 ```
 
 The SDK requires [`uv`](https://docs.astral.sh/uv/) on PATH for automatic

--- a/README.md
+++ b/README.md
@@ -22,8 +22,23 @@ FetchContent_MakeAvailable(hegel)
 target_link_libraries(your_target PRIVATE hegel)
 ```
 
-The `hegel` CLI is installed automatically during the CMake build. If you
-already have it on your PATH, it will be used instead.
+### Hegel server
+
+The SDK automatically manages the `hegel` server binary. During the CMake
+configure step it creates a project-local `.hegel/venv` virtualenv and installs
+the pinned version of [hegel-core](https://github.com/antithesishq/hegel-core)
+into it. Subsequent configures reuse the cached binary unless the pinned
+version changes.
+
+To use your own `hegel` binary instead (e.g. a local development build), set
+the `HEGEL_CMD` environment variable:
+
+```bash
+export HEGEL_CMD=/path/to/hegel
+```
+
+The SDK requires [`uv`](https://docs.astral.sh/uv/) on PATH for automatic
+server management.
 
 ## Quick Start
 
@@ -55,7 +70,8 @@ For a full walkthrough, see [docs/getting-started.md](docs/getting-started.md).
 
 ## Development
 
-Prerequisites: C++20 compiler, CMake 3.14+, [just](https://github.com/casey/just),
+Prerequisites: C++20 compiler, CMake 3.14+, [uv](https://docs.astral.sh/uv/),
+[just](https://github.com/casey/just),
 [clang-format](https://clang.llvm.org/docs/ClangFormat.html).
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,7 @@
+RELEASE_TYPE: minor
+
+The hegel server binary is now managed via a pinned `HEGEL_VERSION` in
+`CMakeLists.txt`. CMake configure installs the exact hegel-core commit into
+a project-local `.hegel/venv` with version caching, replacing the old
+PATH-lookup and auto-install approach. Set `HEGEL_CMD` to override to a
+custom binary at runtime. Requires `uv` on PATH.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,3 @@
 RELEASE_TYPE: minor
 
-The hegel server binary is now managed via a pinned `HEGEL_VERSION` in
-`CMakeLists.txt`. CMake configure installs the exact hegel-core commit into
-a project-local `.hegel/venv` with version caching, replacing the old
-PATH-lookup and auto-install approach. Set `HEGEL_CMD` to override to a
-custom binary at runtime. Requires `uv` on PATH.
+Automatically manage hegel server installation. Adds a runtime requirement on `uv`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,10 +25,14 @@ FetchContent_MakeAvailable(hegel)
 target_link_libraries(your_target PRIVATE hegel)
 ```
 
-During the build, hegel-cpp will automatically install the `hegel` server via `uv` if it is not already on your
-PATH.
+During the CMake configure step, hegel-cpp automatically installs the pinned
+version of [hegel-core](https://github.com/antithesishq/hegel-core) into a
+project-local `.hegel/venv` virtualenv. Subsequent configures reuse the
+cached binary unless the pinned version changes. To use your own `hegel`
+binary instead, set the `HEGEL_CMD` environment variable.
 
-Requirements: a C++20 compiler and CMake 3.14 or later.
+Requirements: a C++20 compiler, CMake 3.14 or later, and
+[uv](https://docs.astral.sh/uv/) on PATH.
 
 ## Write your first test
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,7 @@ During the CMake configure step, hegel-cpp automatically installs the pinned
 version of [hegel-core](https://github.com/antithesishq/hegel-core) into a
 project-local `.hegel/venv` virtualenv. Subsequent configures reuse the
 cached binary unless the pinned version changes. To use your own `hegel`
-binary instead, set the `HEGEL_CMD` environment variable.
+binary instead, set the `HEGEL_SERVER_COMMAND` environment variable.
 
 Requirements: a C++20 compiler, CMake 3.14 or later, and
 [uv](https://docs.astral.sh/uv/) on PATH.

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 setup:
-    @echo "hegel is installed automatically during cmake configure."
+    @echo "hegel is auto-installed at runtime into .hegel/venv"
     @echo "To override, set HEGEL_CMD to the path of your hegel binary."
 
 build:

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 setup:
     @echo "hegel is auto-installed at runtime into .hegel/venv"
-    @echo "To override, set HEGEL_CMD to the path of your hegel binary."
+    @echo "To override, set HEGEL_SERVER_COMMAND to the path of your hegel binary."
 
 build:
     cmake -B build -DCMAKE_BUILD_TYPE=Release

--- a/justfile
+++ b/justfile
@@ -1,12 +1,6 @@
 setup:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -n "${HEGEL_BINARY:-}" ]; then
-        mkdir -p "$HOME/.local/bin"
-        ln -sf "$HEGEL_BINARY" "$HOME/.local/bin/hegel"
-    else
-        uv tool install "hegel @ git+ssh://git@github.com/antithesishq/hegel.git"
-    fi
+    @echo "hegel is installed automatically during cmake configure."
+    @echo "To override, set HEGEL_CMD to the path of your hegel binary."
 
 build:
     cmake -B build -DCMAKE_BUILD_TYPE=Release
@@ -38,8 +32,8 @@ check:
 build-conformance: build
 
 conformance: build-conformance
-    uv run --with "hegel @ git+ssh://git@github.com/antithesishq/hegel.git" \
-        --with pytest --with hypothesis \
+    uv run --with "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git" \
+        --with pytest --with pytest-subtests --with hypothesis \
         pytest tests/conformance/test_conformance.py --durations=20 --durations-min=1.0
 
 docs:

--- a/justfile
+++ b/justfile
@@ -46,3 +46,12 @@ format:
 
 format-check:
     find . \( -name "*.cpp" -o -name "*.h" -o -name "*.hpp" \) ! -path "./build/*" | xargs uvx clang-format --dry-run -Werror
+
+update-hegel-core-version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tag=$(gh api repos/antithesishq/hegel-core/releases/latest --jq '.tag_name')
+    sed -i '' "s/static const std::string HEGEL_VERSION = \".*\"/static const std::string HEGEL_VERSION = \"${tag}\"/" src/hegel.cpp
+    echo "Updated HEGEL_VERSION to ${tag}"
+    # Clear cached install so the next test run picks up the new version
+    rm -rf .hegel/venv

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -88,6 +88,7 @@
           cmakeFlags = (mkFetchContentFlags pkgs) ++ [
             (lib.cmakeFeature "HEGEL_BUILD_DOCS" "ON")
             (lib.cmakeFeature "HEGEL_BUILD_EXAMPLES" "OFF")
+            (lib.cmakeFeature "HEGEL_PATH" "${hegel.packages.${system}.default}/bin/hegel")
           ];
 
           doCheck = true;

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
-    hegel.url = "git+ssh://git@github.com/antithesishq/hegel";
+    hegel.url = "git+ssh://git@github.com/antithesishq/hegel-core";
   };
 
   outputs =

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -130,6 +131,18 @@ namespace hegel {
             hegel_path = find_hegel();
         }
         uint64_t test_cases = options.test_cases.value_or(100);
+
+        // Redirect stdout/stderr to .hegel/server.log
+        std::filesystem::create_directories(HEGEL_DIR);
+        int log_fd = open((HEGEL_DIR + "/server.log").c_str(),
+                          O_WRONLY | O_CREAT | O_APPEND, 0644);
+        if (log_fd >= 0) {
+            dup2(log_fd, STDOUT_FILENO);
+            dup2(log_fd, STDERR_FILENO);
+            ::close(log_fd);
+        }
+
+        setenv("PYTHONUNBUFFERED", "1", 1);
 
         std::vector<std::string> args = {
             hegel_path, socket_path, "--verbosity",

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -20,32 +20,114 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <fstream>
+#include <mutex>
 #include <string>
 #include <vector>
 
 #include <sys/wait.h>
 #include <unistd.h>
 
-// Default path to hegel binary (can be overridden by CMake)
-#ifndef HEGEL_DEFAULT_PATH
-#define HEGEL_DEFAULT_PATH "hegel"
+namespace hegel {
+
+    // =============================================================================
+    // Hegel Binary Discovery / Auto-Install
+    // =============================================================================
+
+    static const std::string HEGEL_VERSION =
+        "6e327df2dd42553de12ace94cfbddfbbd9e4bf50";
+    static const std::string HEGEL_DIR = ".hegel";
+    static const std::string VENV_DIR = HEGEL_DIR + "/venv";
+    static const std::string VERSION_FILE = VENV_DIR + "/hegel-version";
+    static const std::string HEGEL_BIN = VENV_DIR + "/bin/hegel";
+
+    static std::string ensure_hegel_installed() {
+        // Check cached version
+        {
+            std::ifstream f(VERSION_FILE);
+            if (f.is_open()) {
+                std::string cached;
+                std::getline(f, cached);
+                while (!cached.empty() &&
+                       std::isspace(static_cast<unsigned char>(cached.back())))
+                    cached.pop_back();
+                if (cached == HEGEL_VERSION &&
+                    std::filesystem::exists(HEGEL_BIN)) {
+                    return HEGEL_BIN;
+                }
+            }
+        }
+
+        // Create .hegel directory
+        std::filesystem::create_directories(HEGEL_DIR);
+
+        std::cerr << "Installing hegel (" << HEGEL_VERSION.substr(0, 12)
+                  << ") into " << VENV_DIR << "..." << std::endl;
+
+        // Create venv
+        std::string cmd = "uv venv --clear " + VENV_DIR;
+        if (std::system(cmd.c_str()) != 0) {
+            throw std::runtime_error("uv venv failed");
+        }
+
+        // Install hegel
+        std::string pip_spec =
+            "hegel @ git+ssh://git@github.com/antithesishq/hegel-core.git@" +
+            HEGEL_VERSION;
+        cmd = "uv pip install --python " + VENV_DIR + "/bin/python \"" +
+              pip_spec + "\"";
+        if (std::system(cmd.c_str()) != 0) {
+            throw std::runtime_error(
+                "Failed to install hegel (version: " + HEGEL_VERSION +
+                "). "
+                "Set HEGEL_CMD to a hegel binary path to skip "
+                "installation.");
+        }
+
+        if (!std::filesystem::exists(HEGEL_BIN)) {
+            throw std::runtime_error("hegel not found at " + HEGEL_BIN +
+                                     " after installation");
+        }
+
+        // Write version file
+        {
+            std::ofstream f(VERSION_FILE);
+            f << HEGEL_VERSION;
+        }
+
+        return HEGEL_BIN;
+    }
+
+    static std::string cached_hegel_path;
+    static std::once_flag hegel_init_flag;
+
+    static std::string find_hegel() {
+        // 1. HEGEL_CMD env var
+        const char* env = std::getenv("HEGEL_CMD");
+        if (env != nullptr && env[0] != '\0')
+            return std::string(env);
+
+        // 2. Compile-time default (nix builds)
+#ifdef HEGEL_DEFAULT_PATH
+        return HEGEL_DEFAULT_PATH;
 #endif
 
-namespace hegel {
+        // 3. Auto-install
+        std::call_once(hegel_init_flag,
+                       []() { cached_hegel_path = ensure_hegel_installed(); });
+        return cached_hegel_path;
+    }
 
     // =============================================================================
     // Child Process
     // =============================================================================
     static void hegel_child(const std::string& socket_path,
                             const options::HegelOptions& options) {
-        // Priority: HegelOptions.hegel_path > HEGEL_CMD env > compile-time
-        // default
         std::string hegel_path;
         if (options.hegel_path.has_value()) {
             hegel_path = options.hegel_path.value();
         } else {
-            const char* env = std::getenv("HEGEL_CMD");
-            hegel_path = env ? std::string(env) : HEGEL_DEFAULT_PATH;
+            hegel_path = find_hegel();
         }
         uint64_t test_cases = options.test_cases.value_or(100);
 

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -36,7 +36,7 @@ namespace hegel {
     // =============================================================================
 
     static const std::string HEGEL_VERSION =
-        "6e327df2dd42553de12ace94cfbddfbbd9e4bf50";
+        "v0.3.3";
     static const std::string HEGEL_DIR = ".hegel";
     static const std::string VENV_DIR = HEGEL_DIR + "/venv";
     static const std::string VERSION_FILE = VENV_DIR + "/hegel-version";
@@ -62,7 +62,7 @@ namespace hegel {
         // Create .hegel directory
         std::filesystem::create_directories(HEGEL_DIR);
 
-        std::cerr << "Installing hegel (" << HEGEL_VERSION.substr(0, 12)
+        std::cerr << "Installing hegel (" << HEGEL_VERSION
                   << ") into " << VENV_DIR << "..." << std::endl;
 
         // Create venv

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -38,8 +38,14 @@ namespace hegel {
     // =============================================================================
     static void hegel_child(const std::string& socket_path,
                             const options::HegelOptions& options) {
-        std::string hegel_path =
-            options.hegel_path.value_or(HEGEL_DEFAULT_PATH);
+        // Priority: HegelOptions.hegel_path > HEGEL_CMD env > compile-time default
+        std::string hegel_path;
+        if (options.hegel_path.has_value()) {
+            hegel_path = options.hegel_path.value();
+        } else {
+            const char* env = std::getenv("HEGEL_CMD");
+            hegel_path = env ? std::string(env) : HEGEL_DEFAULT_PATH;
+        }
         uint64_t test_cases = options.test_cases.value_or(100);
 
         std::vector<std::string> args = {

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -15,6 +15,7 @@
 #include <socket.h>
 #include <stdexcept>
 
+#include <cctype>
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -35,8 +35,7 @@ namespace hegel {
     // Hegel Binary Discovery / Auto-Install
     // =============================================================================
 
-    static const std::string HEGEL_VERSION =
-        "v0.3.3";
+    static const std::string HEGEL_VERSION = "v0.3.3";
     static const std::string HEGEL_DIR = ".hegel";
     static const std::string VENV_DIR = HEGEL_DIR + "/venv";
     static const std::string VERSION_FILE = VENV_DIR + "/hegel-version";
@@ -62,8 +61,8 @@ namespace hegel {
         // Create .hegel directory
         std::filesystem::create_directories(HEGEL_DIR);
 
-        std::cerr << "Installing hegel (" << HEGEL_VERSION
-                  << ") into " << VENV_DIR << "..." << std::endl;
+        std::cerr << "Installing hegel (" << HEGEL_VERSION << ") into "
+                  << VENV_DIR << "..." << std::endl;
 
         // Create venv
         std::string cmd = "uv venv --clear " + VENV_DIR;

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -81,7 +81,7 @@ namespace hegel {
             throw std::runtime_error(
                 "Failed to install hegel (version: " + HEGEL_VERSION +
                 "). "
-                "Set HEGEL_CMD to a hegel binary path to skip "
+                "Set HEGEL_SERVER_COMMAND to a hegel binary path to skip "
                 "installation.");
         }
 
@@ -103,8 +103,8 @@ namespace hegel {
     static std::once_flag hegel_init_flag;
 
     static std::string find_hegel() {
-        // 1. HEGEL_CMD env var
-        const char* env = std::getenv("HEGEL_CMD");
+        // 1. HEGEL_SERVER_COMMAND env var
+        const char* env = std::getenv("HEGEL_SERVER_COMMAND");
         if (env != nullptr && env[0] != '\0')
             return std::string(env);
 

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -38,7 +38,8 @@ namespace hegel {
     // =============================================================================
     static void hegel_child(const std::string& socket_path,
                             const options::HegelOptions& options) {
-        // Priority: HegelOptions.hegel_path > HEGEL_CMD env > compile-time default
+        // Priority: HegelOptions.hegel_path > HEGEL_CMD env > compile-time
+        // default
         std::string hegel_path;
         if (options.hegel_path.has_value()) {
             hegel_path = options.hegel_path.value();

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/tests/conformance/pyproject.toml
+++ b/tests/conformance/pyproject.toml
@@ -8,4 +8,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-hegel = { git = "ssh://git@github.com/antithesishq/hegel" }
+hegel = { git = "ssh://git@github.com/antithesishq/hegel-core" }

--- a/tests/conformance/uv.lock
+++ b/tests/conformance/uv.lock
@@ -47,7 +47,7 @@ wheels = [
 [[package]]
 name = "hegel"
 version = "0.1.0"
-source = { git = "ssh://git@github.com/antithesishq/hegel#abc37aacd60c9e919beefbf27df434d1c73e5bdc" }
+source = { git = "ssh://git@github.com/antithesishq/hegel-core#abc37aacd60c9e919beefbf27df434d1c73e5bdc" }
 dependencies = [
     { name = "click" },
     { name = "hypothesis" },
@@ -66,7 +66,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hegel", git = "ssh://git@github.com/antithesishq/hegel" },
+    { name = "hegel", git = "ssh://git@github.com/antithesishq/hegel-core" },
     { name = "pytest" },
 ]
 


### PR DESCRIPTION
## Summary

- Manage hegel server binary via a pinned `.hegel/venv` virtualenv, with auto-install at runtime (not CMake configure time), matching the pattern used by other Hegel SDKs
- Pin hegel-core version to release tags (e.g. `v0.3.3`) instead of commit hashes, with a `just update-hegel-core-version` recipe for manual updates
- Redirect hegel server stdout/stderr to `.hegel/server.log` (append mode, `PYTHONUNBUFFERED=1`) for debuggability
- Rename `HEGEL_CMD` env var to `HEGEL_SERVER_COMMAND` (aligning with hegel-rust convention)
- Add release workflow improvements: simplify release notes, fix app token scoping for hegel-core API access, remove `environment: release` from CI
- CI fixes: pin `zizmor==1.23.1` via pipx, suppress `secrets-outside-env` via `.github/zizmor.yml`, fix clang-format and clang-tidy issues, make `uv` optional for nix builds

## Test plan

- [ ] `just check` passes
- [ ] Server log appears at `.hegel/server.log` after test run
- [ ] `HEGEL_SERVER_COMMAND=/path/to/hegel` overrides auto-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)