### PR TITLE
Log server output to .hegel/server.log

### DIFF
--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include <fcntl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -41,6 +42,18 @@ namespace hegel {
         std::string hegel_path =
             options.hegel_path.value_or(HEGEL_DEFAULT_PATH);
         uint64_t test_cases = options.test_cases.value_or(100);
+
+        // Redirect stdout/stderr to .hegel/server.log
+        std::filesystem::create_directories(".hegel");
+        int log_fd = open(".hegel/server.log",
+                          O_WRONLY | O_CREAT | O_APPEND, 0644);
+        if (log_fd >= 0) {
+            dup2(log_fd, STDOUT_FILENO);
+            dup2(log_fd, STDERR_FILENO);
+            ::close(log_fd);
+        }
+
+        setenv("PYTHONUNBUFFERED", "1", 1);
 
         std::vector<std::string> args = {
             hegel_path, socket_path, "--verbosity",


### PR DESCRIPTION
## Summary

- Redirect hegel server subprocess stdout/stderr to `.hegel/server.log` (append mode) instead of inheriting parent's stdio
- Set `PYTHONUNBUFFERED=1` so log output is written promptly
- In the forked child process, use `open()`/`dup2()` to redirect before `execvp()`

Matches the approach taken in https://github.com/antithesishq/hegel-rust/pull/45.

## Test plan

- [ ] Run tests and verify they still pass
- [ ] Check that `.hegel/server.log` is created and contains server output

🤖 Generated with [Claude Code](https://claude.com/claude-code)