### PR TITLE
Add CLAUDE.local.md and .claude/local/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ result
 .claude/*.local.md
 .claude/*.local.json
 .claude/*.local
+.claude/local/
 .claude-reliability/
+CLAUDE.local.md


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Adds gitignore entries for `CLAUDE.local.md` (top-level local instructions file) and `.claude/local/` (directory for local skills and personal Claude config), so developers can use these for personal workflow preferences without accidentally committing them.

This is part of a cross-repo standardization of Claude-related gitignore patterns across all hegel repos.

</details>