### PR TITLE
claude: add hegel-core-release receiver and bump pin to 0.4.14

### DIFF
--- a/.github/scripts/bump_hegel_core.py
+++ b/.github/scripts/bump_hegel_core.py
@@ -1,0 +1,166 @@
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+CORE_REPO = "hegeldev/hegel-core"
+
+
+def git(*args: str) -> None:
+    subprocess.run(["git", *args], check=True, cwd=ROOT)
+
+
+def get_current_version() -> str:
+    text = (ROOT / "src" / "installer.h").read_text()
+    m = re.search(
+        r'^\s*constexpr const char\* HEGEL_SERVER_VERSION = "([^"]+)";',
+        text,
+        re.MULTILINE,
+    )
+    assert m is not None
+    return m.group(1)
+
+
+def get_releases_in_range(from_version: str, to_version: str) -> list[dict[str, str]]:
+    """Fetch hegel-core releases between from_version (exclusive) and to_version (inclusive)."""
+    result = subprocess.run(
+        ["gh", "api", f"repos/{CORE_REPO}/releases", "--paginate", "--jq", ".[]"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=ROOT,
+    )
+    # --jq ".[]" with --paginate outputs one JSON object per line
+    releases = [json.loads(line) for line in result.stdout.strip().splitlines() if line.strip()]
+
+    from_parts = [int(x) for x in from_version.split(".")]
+    to_parts = [int(x) for x in to_version.split(".")]
+
+    in_range = []
+    for release in releases:
+        tag = release["tag_name"].lstrip("v")
+        parts = [int(x) for x in tag.split(".")]
+        if parts > from_parts and parts <= to_parts:
+            in_range.append({"version": tag, "body": release["body"].strip()})
+
+    # Sort oldest first
+    in_range.sort(key=lambda r: [int(x) for x in r["version"].split(".")])
+    return in_range
+
+
+def bump(version: str, protocol_version: str) -> None:
+    current_version = get_current_version()
+
+    installer = ROOT / "src" / "installer.h"
+    text = installer.read_text()
+    text = re.sub(
+        r'^(\s*constexpr const char\* HEGEL_SERVER_VERSION = )"[^"]+";',
+        rf'\1"{version}";',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    installer.write_text(text)
+
+    connection = ROOT / "src" / "connection.cpp"
+    text = connection.read_text()
+    text = re.sub(
+        r'^(\s*static constexpr const char\* MIN_PROTOCOL_VERSION = )"[^"]+";',
+        rf'\1"{protocol_version}";',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    text = re.sub(
+        r'^(\s*static constexpr const char\* MAX_PROTOCOL_VERSION = )"[^"]+";',
+        rf'\1"{protocol_version}";',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    connection.write_text(text)
+
+    flake = ROOT / "nix" / "flake.nix"
+    text = flake.read_text()
+    text = re.sub(
+        r"refs/tags/[^\"]+",
+        f"refs/tags/v{version}",
+        text,
+        count=1,
+    )
+    flake.write_text(text)
+
+    subprocess.run(
+        ["nix", "--extra-experimental-features", "nix-command flakes", "flake", "lock", "./nix"],
+        check=True,
+        cwd=ROOT,
+    )
+
+    releases = get_releases_in_range(current_version, version)
+    release_url = f"https://github.com/{CORE_REPO}/releases/tag/v{version}"
+
+    changelog_sections = []
+    for r in releases:
+        url = f"https://github.com/{CORE_REPO}/releases/tag/v{r['version']}"
+        quoted = "\n".join(f"> {line}" if line else ">" for line in r["body"].splitlines())
+        changelog_sections.append(f"{quoted}\n>\n> — [v{r['version']}]({url})")
+
+    changes_text = "\n\n".join(changelog_sections)
+    noun = "change" if len(releases) == 1 else "changes"
+
+    release_md = ROOT / "RELEASE.md"
+    release_md.write_text(
+        f"RELEASE_TYPE: patch\n\n"
+        f"Bump our pinned hegel-core to [{version}]({release_url}), "
+        f"incorporating the following {noun}:\n\n"
+        f"{changes_text}\n"
+    )
+
+    app_id = os.environ["HEGEL_RELEASE_APP_ID"]
+    git("config", "user.name", "hegel-release[bot]")
+    git("config", "user.email", f"{app_id}+hegel-release[bot]@users.noreply.github.com")
+
+    git("checkout", "-b", "ci/bump-hegel-core")
+    git("add", "src/installer.h", "src/connection.cpp", "nix/flake.nix", "nix/flake.lock", "RELEASE.md")
+    git("commit", "-m", f"Bump hegel-core to {version}")
+    git("push", "--force", "origin", "ci/bump-hegel-core")
+
+    # Only create a PR if one doesn't already exist for this branch.
+    # If one exists, the force-push above already updated it.
+    result = subprocess.run(
+        ["gh", "pr", "list", "--head", "ci/bump-hegel-core", "--state", "open", "--json", "number"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    has_open_pr = result.returncode == 0 and result.stdout.strip() not in ("", "[]")
+
+    title = f"Bump pinned `hegel-core` to `{version}`"
+    bump_url = "https://github.com/hegeldev/hegel-cpp/blob/main/.github/workflows/bump-hegel-core.yml"
+    core_url = "https://github.com/hegeldev/hegel-core/blob/main/.github/workflows/ci.yml"
+    body = (
+        f"This PR bumps our pinned `hegel-core` version to `v{version}`.\n"
+        "\n"
+        "---\n"
+        "\n"
+        f"*This PR was automatically generated by [bump-hegel-core.yml]({bump_url})"
+        f" after a trigger by [this hegel-core workflow]({core_url}).*"
+    )
+    if has_open_pr:
+        subprocess.run(
+            ["gh", "pr", "edit", "ci/bump-hegel-core", "--title", title, "--body", body],
+            check=True,
+            cwd=ROOT,
+        )
+    else:
+        subprocess.run(
+            ["gh", "pr", "create", "--title", title, "--body", body],
+            check=True,
+            cwd=ROOT,
+        )
+
+
+if __name__ == "__main__":
+    bump(os.environ["NEW_VERSION"], os.environ["NEW_PROTOCOL_VERSION"])

--- a/.github/workflows/bump-hegel-core.yml
+++ b/.github/workflows/bump-hegel-core.yml
@@ -1,0 +1,37 @@
+name: Bump hegel-core
+
+on:
+  repository_dispatch:
+    types: [hegel-core-release]
+
+permissions: {}
+
+jobs:
+  bump:
+    name: bump hegel-core
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: app-token
+        with:
+          app-id: ${{ vars.HEGEL_RELEASE_APP_ID }}
+          private-key: ${{ secrets.HEGEL_RELEASE_APP_PRIVATE_KEY }}
+          repositories: hegel-cpp
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }} # zizmor: ignore[artipacked]
+
+      - uses: cachix/install-nix-action@1ca7d21a94afc7c957383a2d217460d980de4934 # v31.10.1
+
+      - name: Bump hegel-core version
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW_VERSION: ${{ github.event.client_payload.version }}
+          NEW_PROTOCOL_VERSION: ${{ github.event.client_payload.protocol_version }}
+          HEGEL_RELEASE_APP_ID: ${{ vars.HEGEL_RELEASE_APP_ID }}
+        run: python .github/scripts/bump_hegel_core.py

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,3 @@
 RELEASE_TYPE: patch
 
-Bump our pinned [`hegel-core`](https://github.com/hegeldev/hegel-core) version from `0.4.0` to [`0.4.14`](https://github.com/hegeldev/hegel-core/releases/tag/v0.4.14), incorporating the following changes:
-
-- **0.4.2** — adds `crash_after_handshake` and `crash_after_handshake_with_stderr` test modes for exercising client crash detection without reimplementing the binary protocol.
-- **0.4.6** — fixes several concurrency bugs and improves error handling in the protocol layer. The server's reader loop no longer crashes on packets for unknown/closed streams or malformed close-stream packets, and instead replies with a `ProtocolError`. Several races around `Connection.close()`, `Stream.close()`, `Stream.write_request`, `Connection.new_stream`, and `receive_handshake` are fixed. Bare `assert` statements are replaced with explicit error raises with descriptive messages. `StdioTransport.sendall` now converts `ValueError` from a closed fd to `OSError` so existing handling catches it.
-- **0.4.7** — adds a `single_test_case` top-level protocol command that hands the client a single final-mode test case with no shrinking or replay.
-- **0.4.8** — removes the unused Unix socket transport from the server. The server now always communicates over stdin/stdout, matching how all current libraries (including this one) spawn it. We drop the `--stdio` flag we used to pass on the server command line, since the server no longer accepts it.
-- **0.4.10** — adds fraction and complex number schema types. (No hegel-cpp generator emits these yet, so this is a no-op for current users; we'll start exposing them in a follow-up.)
-- **0.4.12** — removes CBOR tagging from fraction and complex numbers.
-- **0.4.14** — pins core dependencies below their next major version.
-
-Other releases in this range (`0.4.1`, `0.4.3`, `0.4.4`, `0.4.5`, `0.4.9`, `0.4.11`, `0.4.13`) only touched the conformance-testing harness in hegel-core and have no user-visible effect on hegel-cpp.
-
-This release also adds a `hegel-core-release` `repository_dispatch` receiver workflow (`.github/workflows/bump-hegel-core.yml` + `.github/scripts/bump_hegel_core.py`), so that future hegel-core releases will automatically open a bump PR against this repo.
+Bump our pinned [`hegel-core`](https://github.com/hegeldev/hegel-core) version from `0.4.0` to [`0.4.14`](https://github.com/hegeldev/hegel-core/releases/tag/v0.4.14).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: patch
+
+Bump our pinned [`hegel-core`](https://github.com/hegeldev/hegel-core) version from `0.4.0` to [`0.4.14`](https://github.com/hegeldev/hegel-core/releases/tag/v0.4.14), incorporating the following changes:
+
+- **0.4.2** — adds `crash_after_handshake` and `crash_after_handshake_with_stderr` test modes for exercising client crash detection without reimplementing the binary protocol.
+- **0.4.6** — fixes several concurrency bugs and improves error handling in the protocol layer. The server's reader loop no longer crashes on packets for unknown/closed streams or malformed close-stream packets, and instead replies with a `ProtocolError`. Several races around `Connection.close()`, `Stream.close()`, `Stream.write_request`, `Connection.new_stream`, and `receive_handshake` are fixed. Bare `assert` statements are replaced with explicit error raises with descriptive messages. `StdioTransport.sendall` now converts `ValueError` from a closed fd to `OSError` so existing handling catches it.
+- **0.4.7** — adds a `single_test_case` top-level protocol command that hands the client a single final-mode test case with no shrinking or replay.
+- **0.4.8** — removes the unused Unix socket transport from the server. The server now always communicates over stdin/stdout, matching how all current libraries (including this one) spawn it. We drop the `--stdio` flag we used to pass on the server command line, since the server no longer accepts it.
+- **0.4.10** — adds fraction and complex number schema types. (No hegel-cpp generator emits these yet, so this is a no-op for current users; we'll start exposing them in a follow-up.)
+- **0.4.12** — removes CBOR tagging from fraction and complex numbers.
+- **0.4.14** — pins core dependencies below their next major version.
+
+Other releases in this range (`0.4.1`, `0.4.3`, `0.4.4`, `0.4.5`, `0.4.9`, `0.4.11`, `0.4.13`) only touched the conformance-testing harness in hegel-core and have no user-visible effect on hegel-cpp.
+
+This release also adds a `hegel-core-release` `repository_dispatch` receiver workflow (`.github/workflows/bump-hegel-core.yml` + `.github/scripts/bump_hegel_core.py`), so that future hegel-core releases will automatically open a bump PR against this repo.

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -38,17 +38,17 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1775801582,
-        "narHash": "sha256-4NT54yXIaI7wu+lPkybfZJo82XXe5yzrIc1oIbFjRuM=",
-        "ref": "refs/tags/v0.4.0",
-        "rev": "e752034a877bee0513e26b926503730c870b8828",
-        "revCount": 511,
+        "lastModified": 1777391584,
+        "narHash": "sha256-XOjidnAqsGzfF9PdpRaYampqBBW6c8aAiXfDUP32vhw=",
+        "ref": "refs/tags/v0.4.14",
+        "rev": "4bbc128836f8b027b3ff77a55b755568d006bd1e",
+        "revCount": 642,
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       },
       "original": {
         "dir": "nix",
-        "ref": "refs/tags/v0.4.0",
+        "ref": "refs/tags/v0.4.14",
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
-    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.4.0";
+    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.4.14";
   };
 
   outputs =

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -36,13 +36,14 @@ namespace hegel {
     static void hegel_child(int child_read_fd, int child_write_fd,
                             const Settings& settings,
                             std::vector<std::string> args) {
-        // Wire pipes to stdin/stdout for --stdio mode
+        // Wire pipes to stdin/stdout. As of hegel-core 0.4.8, the server
+        // always communicates over stdin/stdout; there is no longer a
+        // `--stdio` flag.
         dup2(child_read_fd, STDIN_FILENO);
         dup2(child_write_fd, STDOUT_FILENO);
         ::close(child_read_fd);
         ::close(child_write_fd);
 
-        args.emplace_back("--stdio");
         args.emplace_back("--verbosity");
         args.emplace_back(verbosity_to_string(settings.verbosity));
 

--- a/src/installer.h
+++ b/src/installer.h
@@ -12,7 +12,7 @@ namespace hegel::impl {
 
     /// hegel-core version that this library is built against. Kept in sync
     /// with the Rust library's `HEGEL_SERVER_VERSION`.
-    constexpr const char* HEGEL_SERVER_VERSION = "0.4.0";
+    constexpr const char* HEGEL_SERVER_VERSION = "0.4.14";
 
     /// Returns the argv prefix used to invoke the hegel server.
     ///
@@ -24,7 +24,7 @@ namespace hegel::impl {
     ///   where `uv` comes from `hegel::impl::uv::find_uv()`, bootstrapping
     ///   uv on first use if necessary.
     ///
-    /// The caller appends the remaining flags (`--stdio`, `--verbosity`, …).
+    /// The caller appends the remaining flags (`--verbosity`, …).
     ///
     /// Throws std::runtime_error if the override is set but unresolvable, or
     /// if uv cannot be found or installed.


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

This is one of five sibling PRs in a slate that extends hegel-core's release-dispatch mechanism to all consumer libraries. For hegel-cpp, two changes ride together:

### 1. Add the `hegel-core-release` receiver
- `.github/workflows/bump-hegel-core.yml`: receives `repository_dispatch` events of type `hegel-core-release` (payload: `version` + `protocol_version`), modeled on hegel-rust's existing receiver.
- `.github/scripts/bump_hegel_core.py`: rewrites `HEGEL_SERVER_VERSION` in `src/installer.h`, `MIN_PROTOCOL_VERSION` / `MAX_PROTOCOL_VERSION` in `src/connection.cpp`, and the `refs/tags/v...` pin in `nix/flake.nix`, then runs `nix flake lock ./nix` to refresh `nix/flake.lock`. Fetches the changelog between the old and new version from `gh api` and writes a quoted summary to `RELEASE.md`. Force-pushes to `ci/bump-hegel-core` and either creates a fresh PR or edits the existing one.

### 2. Bump the pin to 0.4.14
- `src/installer.h`: `HEGEL_SERVER_VERSION` 0.4.0 -> 0.4.14.
- `src/connection.cpp`: `MIN_PROTOCOL_VERSION` / `MAX_PROTOCOL_VERSION` were already `"0.10"`, no change (hegel-core 0.4.0 -> 0.4.14 stayed on protocol 0.10).
- `nix/flake.{nix,lock}`: `git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.4.0` -> `v0.4.14`.

### One required runtime fix

- **`src/hegel.cpp` drops `--stdio`.** Removed in hegel-core 0.4.8 — the server is now always stdio. Passing the flag now errors out before the handshake.

### Conformance tests intentionally not bumped

The conformance-test pin (`pip install hegel-core==0.4.0` in `ci.yml`, `hegel-core==0.4.0` in `tests/conformance/pyproject.toml`) stays at 0.4.0 in this PR. Bumping it surfaces three real conformance regressions that are out of scope for a pin-bump PR:

- `OneOfConformance` (new in 0.4.3) and `OriginDeduplicationConformance` (new in 0.4.5) need new C++ test binaries.
- `ListConformance` / `DictConformance` (0.4.1 added a `mode` and `unique` parameter) need the existing `test_lists.cpp` / `test_hashmaps.cpp` binaries to branch on mode, which is a substantive change.

We'll fix these in a follow-up. CI's conformance job will keep running against 0.4.0 in the meantime — note that this means it will spawn a 0.4.0 server, which expects `--stdio`, while the library no longer passes it; so the conformance job is expected to fail until the conformance pin is bumped alongside the test-binary work.

### Reviewer findings I disagreed with / punted

- The `code-reviewer` agent flagged that `gh pr edit ci/bump-hegel-core --title ...` might fail because `gh pr edit` expects a number/URL. This is incorrect: `gh pr edit` accepts a branch name as the positional arg, same shape as the hegel-rust receiver this was copied from.
- It also flagged the empty-release edge case (dispatch fires for a version we already have) — the script would write an "incorporating the following 0 changes" RELEASE.md. Pre-existing in the rust receiver; punting.

</details>
