### PR TITLE
claude: whitelist .claude in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,10 +11,9 @@ result
 
 .claude-reliability/
 **/.claude/reliability-config.yaml
-.claude/bin/
-.claude/settings.local.json
-.claude/*.local.md
-.claude/*.local.json
-.claude/*.local
-.claude/local/
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
 CLAUDE.local.md


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Switch the `.claude/` section of `.gitignore` from a blacklist (`.claude/bin/`, `.claude/settings.local.json`, `.claude/*.local.md`, `.claude/*.local.json`, `.claude/*.local`, `.claude/local/`) to a whitelist. Local files (skills, agents, settings, plans) inside `.claude/` are now untracked by default; only `.claude/CLAUDE.md` is committed. Top-level `CLAUDE.local.md`, `.claude-reliability/`, and the recursive `**/.claude/reliability-config.yaml` rule (which targets nested test-fixture `.claude/` dirs) are unchanged.

Verified `.claude/CLAUDE.md` is still tracked (`git ls-files .claude/`) and that previously-untracked plait-injected files (`.claude/agents/`, `.claude/skills/`) remain ignored.

</details>
