### PR TITLE
claude: protocol: drop null/ipv4/ipv6 schemas

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,3 +6,14 @@ the latest `hegel-core` protocol: `optional` now emits
 `{"type": "null"}`), and `ip_addresses` now emits
 `{"type": "ip_address", "version": N}` (replacing `{"type": "ipv4"}` /
 `{"type": "ipv6"}`). No public C++ API change.
+
+Bump our pinned hegel-core to [0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0), incorporating the following change:
+
+> This release makes the following breaking protocol changes:
+> - Removed `{"type": "sampled_from"}`. Instead of serializing the values to sample from, ask for an integer index and index into the collection of values on the client side.
+> - Removed `{"type": "null"}`. Use `{"type": "constant", "value": null}` instead.
+> - Replaced `{"type": "ipv4"}` and `{"type": "ipv6"}` with a single `{"type": "ip_address", "version": <4|6>}` schema.
+>
+> The protocol version is now 0.12.
+>
+> — [v0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+RELEASE_TYPE: patch
+
+Update the wire schemas emitted by `optional` and `ip_addresses` to match
+the latest `hegel-core` protocol: `optional` now emits
+`{"type": "constant", "value": null}` for the null branch (replacing
+`{"type": "null"}`), and `ip_addresses` now emits
+`{"type": "ip_addresses", "version": N}` (replacing `{"type": "ipv4"}` /
+`{"type": "ipv6"}`). No public C++ API change.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,19 +1,3 @@
 RELEASE_TYPE: patch
 
-Update the wire schemas emitted by `optional` and `ip_addresses` to match
-the latest `hegel-core` protocol: `optional` now emits
-`{"type": "constant", "value": null}` for the null branch (replacing
-`{"type": "null"}`), and `ip_addresses` now emits
-`{"type": "ip_address", "version": N}` (replacing `{"type": "ipv4"}` /
-`{"type": "ipv6"}`). No public C++ API change.
-
-Bump our pinned hegel-core to [0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0), incorporating the following change:
-
-> This release makes the following breaking protocol changes:
-> - Removed `{"type": "sampled_from"}`. Instead of serializing the values to sample from, ask for an integer index and index into the collection of values on the client side.
-> - Removed `{"type": "null"}`. Use `{"type": "constant", "value": null}` instead.
-> - Replaced `{"type": "ipv4"}` and `{"type": "ipv6"}` with a single `{"type": "ip_address", "version": <4|6>}` schema.
->
-> The protocol version is now 0.12.
->
-> — [v0.6.0](https://github.com/hegeldev/hegel-core/releases/tag/v0.6.0)
+Internal refactor.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,5 +4,5 @@ Update the wire schemas emitted by `optional` and `ip_addresses` to match
 the latest `hegel-core` protocol: `optional` now emits
 `{"type": "constant", "value": null}` for the null branch (replacing
 `{"type": "null"}`), and `ip_addresses` now emits
-`{"type": "ip_addresses", "version": N}` (replacing `{"type": "ipv4"}` /
+`{"type": "ip_address", "version": N}` (replacing `{"type": "ipv4"}` /
 `{"type": "ipv6"}`). No public C++ API change.

--- a/include/hegel/generators/combinators.h
+++ b/include/hegel/generators/combinators.h
@@ -300,7 +300,8 @@ namespace hegel::generators {
 
             hegel::internal::json::json generators =
                 hegel::internal::json::json::array();
-            generators.push_back(hegel::internal::json::json{{"type", "null"}});
+            generators.push_back(hegel::internal::json::json{
+                {"type", "constant"}, {"value", nullptr}});
             generators.push_back(basic->schema);
             hegel::internal::json::json schema = {{"type", "one_of"},
                                                   {"generators", generators}};

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -38,17 +38,17 @@
       },
       "locked": {
         "dir": "nix",
-        "lastModified": 1777479227,
-        "narHash": "sha256-s1JjMvJX3SRebwlSQeo6S99OWIoP0CFuPALvG1itzGw=",
-        "ref": "refs/tags/v0.5.0",
-        "rev": "a95da271bb026037d13656b4317a445a308fded3",
-        "revCount": 653,
+        "lastModified": 1777568232,
+        "narHash": "sha256-VInDnyh7uxm6d9IyfV3ShxHZD4BvsTF7wIB+kv9apbk=",
+        "ref": "refs/tags/v0.6.0",
+        "rev": "4630a7845bff88908be4505675a945711f43b5bd",
+        "revCount": 658,
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       },
       "original": {
         "dir": "nix",
-        "ref": "refs/tags/v0.5.0",
+        "ref": "refs/tags/v0.6.0",
         "type": "git",
         "url": "https://github.com/hegeldev/hegel-core"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
-    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.5.0";
+    hegel.url = "git+https://github.com/hegeldev/hegel-core?dir=nix&ref=refs/tags/v0.6.0";
   };
 
   outputs =

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -18,8 +18,8 @@
 using hegel::internal::json::ImplUtil;
 
 namespace hegel::impl {
-    static constexpr const char* MIN_PROTOCOL_VERSION = "0.11";
-    static constexpr const char* MAX_PROTOCOL_VERSION = "0.11";
+    static constexpr const char* MIN_PROTOCOL_VERSION = "0.12";
+    static constexpr const char* MAX_PROTOCOL_VERSION = "0.12";
     static constexpr const char* HANDSHAKE_STRING = "hegel_handshake_start";
 
     Connection::Connection(int read_fd, int write_fd)

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -227,7 +227,7 @@ namespace hegel::generators {
             std::optional<BasicGenerator<std::string>>
             as_basic() const override {
                 return BasicGenerator<std::string>{
-                    {{"type", "ip_addresses"}, {"version", version_}},
+                    {{"type", "ip_address"}, {"version", version_}},
                     &default_parse_raw<std::string>};
             }
 

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -227,7 +227,7 @@ namespace hegel::generators {
             std::optional<BasicGenerator<std::string>>
             as_basic() const override {
                 return BasicGenerator<std::string>{
-                    {{"type", version_ == 4 ? "ipv4" : "ipv6"}},
+                    {{"type", "ip_addresses"}, {"version", version_}},
                     &default_parse_raw<std::string>};
             }
 

--- a/src/installer.h
+++ b/src/installer.h
@@ -12,7 +12,7 @@ namespace hegel::impl {
 
     /// hegel-core version that this library is built against. Kept in sync
     /// with the Rust library's `HEGEL_SERVER_VERSION`.
-    constexpr const char* HEGEL_SERVER_VERSION = "0.5.0";
+    constexpr const char* HEGEL_SERVER_VERSION = "0.6.0";
 
     /// Returns the argv prefix used to invoke the hegel server.
     ///


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Update the JSON schemas the C++ client emits to match the latest `hegel-core` protocol:

- `optional` now emits `{"type": "constant", "value": null}` for its null branch (replacing `{"type": "null"}`)
- `ip_addresses` now emits `{"type": "ip_addresses", "version": N}` (replacing `{"type": "ipv4"}` / `{"type": "ipv6"}`)

The C++ client never emitted a `sampled_from` schema — it already lowers `sampled_from` to an integer-index draw — so there is no source change for that issue.

Coordinated with the hegel-core protocol cleanup:
- https://github.com/hegeldev/hegel-core/issues/77
- https://github.com/hegeldev/hegel-core/issues/78
- https://github.com/hegeldev/hegel-core/issues/82

### Expected CI failures

The conformance / integration tests run against the installed `hegel` binary and will fail until the coordinated `hegel-core` PR merges and publishes a release. Unit tests, build, and format checks pass.

### Self-review notes

The `code-reviewer` subagent flagged three points; addressing each:

- *Bump pinned `hegel-core==0.4.0` in `tests/conformance/pyproject.toml`* — this file is not consumed by `just check-conformance` (which calls `uv run --with hegel-core` unpinned), so the pin is silently dead. Out of scope for this coordinated protocol PR; can be cleaned up separately.
- *Consider `RELEASE_TYPE: minor` over `patch`* — the task spec for this coordinated update directs `patch` since there is no public C++ API change. The wire-format compatibility break is what motivates the simultaneous landing across hegel-core + clients, so the patch level matches the rest of the cohort.
- *Add unit tests asserting the literal JSON shapes* — the codebase has no existing wire-shape assertions for any schema (only `schema().has_value()` checks); adding them just here would be inconsistent. Better tackled as a follow-up that covers all schemas at once.

</details>
