### PR TITLE
claude: flip from_regex default to fullmatch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: major
+RELEASE_TYPE: minor
 
 This release changes the default value of `fullmatch` in `from_regex` from `false` to `true`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,3 @@
 RELEASE_TYPE: major
 
-The default match mode of `from_regex` is now fullmatch: `from_regex(pattern)` generates strings where the entire string matches the pattern, as if anchored with `^...$`. Previously the generated string only needed to *contain* a match, so arbitrary characters could surround it.
-
-```cpp
-auto g = from_regex("[A-Z]{2}-[0-9]{4}");
-// before: "xx QX-8271 yy"  (string need only contain a match)
-// after:  "QX-8271"        (entire string matches, as if anchored with ^...$)
-
-from_regex("[A-Z]{2}-[0-9]{4}", false);  // restores the old behavior
-```
+This release changes the default value of `fullmatch` in `from_regex` from `false` to `true`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+RELEASE_TYPE: major
+
+The default match mode of `from_regex` is now fullmatch: `from_regex(pattern)` generates strings where the entire string matches the pattern, as if anchored with `^...$`. Previously the generated string only needed to *contain* a match, so arbitrary characters could surround it.
+
+```cpp
+auto g = from_regex("[A-Z]{2}-[0-9]{4}");
+// before: "xx QX-8271 yy"  (string need only contain a match)
+// after:  "QX-8271"        (entire string matches, as if anchored with ^...$)
+
+from_regex("[A-Z]{2}-[0-9]{4}", false);  // restores the old behavior
+```

--- a/include/hegel/generators/strings.h
+++ b/include/hegel/generators/strings.h
@@ -89,27 +89,27 @@ namespace hegel::generators {
      * @brief Generate strings matching a regular expression.
      *
      * @code{.cpp}
-     * // Default: generated string only needs to *contain* a match,
-     * // so arbitrary prefix/suffix characters may surround it.
-     * auto loose = from_regex("[A-Z]{2}-[0-9]{4}");
-     * // e.g. "xx QX-8271 yy"
-     *
-     * // fullmatch = true: the entire generated string matches the pattern,
+     * // Default: the entire generated string matches the pattern,
      * // as if anchored with ^...$.
-     * auto strict = from_regex("[A-Z]{2}-[0-9]{4}", true);
+     * auto strict = from_regex("[A-Z]{2}-[0-9]{4}");
      * // e.g. "QX-8271"
+     *
+     * // fullmatch = false: generated string only needs to *contain* a match,
+     * // so arbitrary prefix/suffix characters may surround it.
+     * auto loose = from_regex("[A-Z]{2}-[0-9]{4}", false);
+     * // e.g. "xx QX-8271 yy"
      * @endcode
      *
      * @param pattern Regex pattern
-     * @param fullmatch If `true`, the entire generated string must match
-     *   the pattern (equivalent to anchoring with `^` and `$`). If `false`
-     *   (default), the generated string need only contain a substring that
+     * @param fullmatch If `true` (default), the entire generated string must
+     *   match the pattern (equivalent to anchoring with `^` and `$`). If
+     *   `false`, the generated string need only contain a substring that
      *   matches; arbitrary characters may appear before or after the match.
      * @return Generator producing strings that satisfy @p pattern under the
      *   selected match mode.
      */
     Generator<std::string> from_regex(const std::string& pattern,
-                                      bool fullmatch = false);
+                                      bool fullmatch = true);
 
     /// @}
 

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -24,7 +24,7 @@ TEST(Formats, DrawAll) {
             (void)tc.draw(gs::times());
             (void)tc.draw(gs::datetimes());
             (void)tc.draw(gs::from_regex("[a-z]{1,5}"));
-            (void)tc.draw(gs::from_regex("[A-Z]{2}", true));
+            (void)tc.draw(gs::from_regex("[A-Z]{2}", false));
             // ip_addresses: v4, v6, and the default (either) factory branches.
             (void)tc.draw(gs::ip_addresses({.v = 4}));
             (void)tc.draw(gs::ip_addresses({.v = 6}));
@@ -78,12 +78,46 @@ TEST(Formats, RegexNonFinalAnchorHonored) {
     const std::regex oracle(R"(\bfoo\b)");
     hegel::test(
         [&](hegel::TestCase& tc) {
-            std::string s = tc.draw(gs::from_regex(R"(\bfoo\b)"));
+            std::string s = tc.draw(gs::from_regex(R"(\bfoo\b)", false));
             EXPECT_TRUE(std::regex_search(s, oracle))
                 << "generated string has no standalone \"foo\": " << s;
         },
         hegel::Settings{.test_cases = 100,
                         .database = hegel::Database::disabled()});
+}
+
+// By default the entire generated string must match the pattern, as if
+// anchored with ^...$ — no surrounding characters are permitted.
+TEST(Formats, RegexDefaultsToFullmatch) {
+    const std::regex oracle("[A-Z]{2}-[0-9]{4}");
+    hegel::test(
+        [&](hegel::TestCase& tc) {
+            std::string s = tc.draw(gs::from_regex("[A-Z]{2}-[0-9]{4}"));
+            EXPECT_TRUE(std::regex_match(s, oracle))
+                << "generated string is not a full match: " << s;
+        },
+        hegel::Settings{.test_cases = 100,
+                        .database = hegel::Database::disabled()});
+}
+
+// fullmatch = false restores contains-a-match behavior: every generated
+// string contains a match, but may carry arbitrary prefix/suffix characters.
+// Padding around the match must actually occur across the run — otherwise this
+// would pass even if the flag were ignored, since a full match also satisfies
+// regex_search.
+TEST(Formats, RegexFullmatchFalseAllowsContains) {
+    const std::regex oracle("[A-Z]{2}-[0-9]{4}");
+    bool saw_padding = false;
+    hegel::test(
+        [&](hegel::TestCase& tc) {
+            std::string s = tc.draw(gs::from_regex("[A-Z]{2}-[0-9]{4}", false));
+            EXPECT_TRUE(std::regex_search(s, oracle))
+                << "generated string contains no match: " << s;
+            saw_padding |= !std::regex_match(s, oracle);
+        },
+        hegel::Settings{.test_cases = 100,
+                        .database = hegel::Database::disabled()});
+    EXPECT_TRUE(saw_padding);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Flips the default match mode of `from_regex` from "contains a match" to fullmatch: `from_regex(pattern)` now generates strings where the entire string matches the pattern, as if anchored with `^...$`. Pass `from_regex(pattern, false)` to restore the contains-a-match behavior.

- Default parameter flipped in `include/hegel/generators/strings.h`; Doxygen example and `@param` text inverted to match.
- Tests: `RegexDefaultsToFullmatch` asserts the default yields only full matches (`std::regex_match`); `RegexFullmatchFalseAllowsContains` asserts the `false` escape hatch produces matches with surrounding padding across the run; existing contains-mode call sites now pass `false` explicitly.
- `RELEASE.md` with `RELEASE_TYPE: minor` (breaking change, but pre-1.0 zerover bumps minor).

Refs hegeldev/hegel-rust#258 (parallel PRs in hegel-rust, hegel-typescript, and hegel-java).

</details>
