### PR TITLE
claude: sync zerover release-type guidance; add changelog skill

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: changelog
+description: "Changelog style guide for writing RELEASE.md files. Use when creating or reviewing RELEASE.md, writing changelog entries, or preparing a PR that needs release notes."
+---
+
+# Changelog Style Guide
+
+This guide describes the style for writing `RELEASE.md` files for hegel-cpp. The style is modeled on the [Hypothesis changelog](https://hypothesis.readthedocs.io/en/latest/changes.html).
+
+## Choosing `RELEASE_TYPE`
+
+hegel-cpp is currently zerover (`0.x.y`), so the usual semver mapping does **not** apply. While we are pre-1.0:
+
+- **`patch`** — Bug fixes, internal changes, **and new features / non-breaking API additions**. The default choice.
+- **`minor`** — **Breaking changes only.** Any change that requires users to update their code (renamed/removed APIs, changed signatures, behavior changes that could break downstream tests) is a minor bump.
+- **`major`** — Not used while we are zerover. Reserve for the eventual 1.0 and beyond.
+
+If you find yourself reaching for `minor` because the change feels "big," check whether it actually breaks any caller. A large new feature that adds API surface without removing or changing existing behavior is still a `patch`.
+
+## Opening sentence pattern
+
+Every entry should open with a sentence that signals the scope and nature of the change:
+
+- **Patch (fixes, improvements, new features):** Start with `"This patch ..."`
+- **Minor (breaking changes):** Start with `"This release ..."` and explain migration
+- **Tiny internal-only changes:** A bare sentence is fine — `"Internal refactoring."` or `"Clean up some internal code."`
+
+The opening verb should tell the reader what *kind* of change this is:
+
+| Change type | RELEASE_TYPE | Opening pattern |
+|---|---|---|
+| Bug fix | `patch` | `"This patch fixes ..."` or `"Fix ..."` |
+| New feature | `patch` | `"This patch adds ..."` |
+| Improvement | `patch` | `"This patch improves ..."` |
+| Performance | `patch` | `"This patch improves the performance of ..."` or `"Optimize ..."` |
+| Deprecation | `minor` | `"This release deprecates ..."` |
+| Breaking change | `minor` | `"This release changes ..."` (then explain migration) |
+| Internal-only | `patch` | `"Internal refactoring."` / `"Refactor some internals."` / `"Clean up some internal code."` |
+
+## Describe the user impact, not the implementation
+
+Bad: "Cache the `hegel_string_generator_t` handle instead of rebuilding it on every draw."
+
+Good: "This patch improves the performance of the string-family generators. `text()`, `from_regex()`, and `emails()` now build their character tables once at generator construction rather than on every draw, which should speed up tests that generate many strings."
+
+Bad: "This patch fixes a bug in integer generation."
+
+Good: "This patch fixes `integers<uint64_t>()` producing out-of-range values when `min_value` was above `INT64_MAX`. Ranges that don't fit in `int64_t` are now bounded correctly."
+
+## Length calibration
+
+- **Internal-only changes:** 1 sentence. (`"Refactor some internals."`)
+- **Simple bug fixes:** 1-3 sentences. Describe the bug and what changed.
+- **New features:** 1-2 short paragraphs. Describe what it does and why it's useful.
+- **Breaking changes / API changes:** Multiple paragraphs. Include before/after code examples and migration guidance.
+
+Don't pad entries. If a change can be described in one sentence, use one sentence.
+
+## Code examples
+
+Include fenced code blocks for:
+- New API features (show usage)
+- Breaking changes (show before/after)
+- Anything where seeing the code is clearer than describing it
+
+Don't include code blocks for bug fixes or internal changes.
+
+## References
+
+- Reference GitHub issues when relevant: `([#123](https://github.com/hegeldev/hegel-cpp/issues/123))`
+- Reference previous versions when building on prior work
+- Reference related libraries/specs when relevant
+
+## Tone
+
+- Third person, present tense for describing behavior
+- Professional but conversational — be direct, not formal
+- Honest about uncertainty: `"This should improve performance"`, `"We expect this to..."`, `"In some cases this may..."`
+- It's okay to briefly explain *why* a change was made if the motivation isn't obvious
+
+## Things to avoid
+
+- No emojis
+- No bullet lists for single-topic entries (use them for multi-topic entries like API cleanups)
+- No commit hashes or PR numbers in the text (issue numbers are fine)
+- Don't describe the implementation when you can describe the effect
+- Don't use vague language like `"various improvements"` — be specific about what changed
+- Don't add marketing language or hype
+
+## Examples
+
+**Good patch (bug fix):**
+
+```
+RELEASE_TYPE: patch
+
+This patch fixes `text()` ignoring `exclude_characters` when `alphabet` was also provided. Excluded characters are now removed from the alphabet before generation.
+```
+
+**Good patch (internal):**
+
+```
+RELEASE_TYPE: patch
+
+Internal refactoring of the engine wrapper code.
+```
+
+**Good patch (new feature):**
+
+```
+RELEASE_TYPE: patch
+
+This patch adds `Settings::report_multiple_failures`. When enabled, `hegel::test()` keeps generating after the first failure to surface additional distinct bugs, and reports all of them at the end of the run, instead of stopping at the first failing example.
+
+This is useful for tests that check several properties at once, where fixing one bug at a time would otherwise require repeated runs.
+```
+
+**Good minor (breaking change):**
+
+````
+RELEASE_TYPE: minor
+
+This release changes `vectors()`, `sets()`, and `maps()` to take a designated-initializer params struct instead of positional size arguments, matching the other generators.
+
+Before:
+
+```cpp
+auto g = vectors(integers<int>(), 1, 10);
+```
+
+After:
+
+```cpp
+auto g = vectors(integers<int>(), {.min_size = 1, .max_size = 10});
+```
+
+To migrate, replace the positional `min`/`max` arguments with a `VectorsParams` (or `SetsParams` / `MapsParams`) initializer as shown above.
+````

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,7 @@ result
 # which we gitignore at the top level.
 .claude/*
 !.claude/CLAUDE.md
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/changelog/
 CLAUDE.local.md

--- a/RELEASE-sample.md
+++ b/RELEASE-sample.md
@@ -6,7 +6,7 @@ This patch adds support for setting `seed` to the protocol.
 
 Every pull request which modifies the source code must include a `RELEASE.md` file. This `RELEASE-sample.md` file is an example of that file.
 
-In the example above, "patch" on the first line should be replaced by "minor" if changes are visible in the public API, or "major" if there are breaking changes.  Note that only maintainers should ever make a major release.
+While we are on a `0.x` major version the semver levels are shifted: **breaking changes are "minor"** and **everything else (bug fixes, internal changes, and new non-breaking features / API additions) is "patch"**. So in the example above, "patch" on the first line should be replaced by "minor" only for a breaking change. "major" is reserved for the eventual 1.0 and beyond, and only maintainers should ever make a major release.
 
 The remaining lines are the actual changelog text for this release, which should:
 


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Syncs the zerover (`0.x.y`) release-type guidance into hegel-cpp, part of a cross-repo effort to replace stale classic-semver wording that recently caused a breaking change to be mislabeled `RELEASE_TYPE: major`.

- `RELEASE-sample.md`: replaces the old "minor if visible in the public API, major if breaking" paragraph with the canonical zerover mapping — everything non-breaking is `patch`, breaking changes are `minor`, and `major` is reserved for 1.0.
- Adds a `changelog` skill at `.claude/skills/changelog/SKILL.md`: a style guide for writing `RELEASE.md` entries (release-type selection, opening-sentence patterns, length calibration, tone), with examples written against real hegel-cpp APIs (`text()`, `integers<uint64_t>()`, `Settings::report_multiple_failures`, `vectors()`/`VectorsParams`).
- `.gitignore`: whitelists `.claude/skills/changelog/` so the skill is tracked, while other local `.claude/skills/*` content stays ignored.

Docs-only; no source changes, so no `RELEASE.md`.

**Reviewer note (from self-review):** the skill's opening-pattern table classifies deprecations as `minor`, while the zerover section defines `minor` as "breaking changes only" — a pure deprecation warning arguably doesn't force a caller update. Left as-is because the table is part of the mandated cross-repo template; if it should change, it should change at the template level across all seven repos.

</details>
