### PR TITLE
Clean up inconsistencies in public API and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,14 @@ failures found in one run are replayed first in the next. (You can also call
 This test will fail! Hegel will produce a minimal failing test case for us:
 
 ```
-Generated: [0,0]
-libc++abi: terminating due to uncaught exception of type std::runtime_error:
-Hegel test failed: sort mismatch
+Generated: 0
+Generated: 0
+terminate called after throwing an instance of 'std::runtime_error'
+  what():  sort mismatch
 ```
 
-Hegel reports the minimal example showing that our sort is incorrectly dropping duplicates.
+Each `Generated:` line is one primitive value drawn while replaying the
+minimal failing example — here the two elements of the shrunken input vector
+`[0, 0]`, showing that our sort incorrectly drops duplicates. (The final two
+lines come from the C++ runtime reporting the uncaught exception, so their
+exact wording varies by platform; the output above is from Linux/libstdc++.)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,12 @@
+RELEASE_TYPE: minor
+
+This release makes the date/time generators return structured values, eliminates several silent failure modes, and corrects a number of inaccurate API docs.
+
+**Breaking change**: `dates()`, `times()`, and `datetimes()` now return the new `hegel::Date`, `hegel::Time`, and `hegel::DateTime` aggregates instead of ISO 8601 strings. The structs expose the drawn fields (`year`/`month`/`day`, `hour`/`minute`/`second`/`microsecond`), compare chronologically, and serialize via `to_string()` or `operator<<`. Serialization always includes the six-digit fractional-seconds field (`HH:MM:SS.ffffff`), so every value has a single canonical string shape; previously the fraction appeared only when the microsecond was nonzero. To recover the old string-valued generators, map the typed ones, e.g. `gs::dates().map([](hegel::Date d) { return d.to_string(); })`.
+
+Other improvements:
+
+- `DerivedGenerator::override` now *replaces* the overridden field's generator, as documented, instead of drawing the default value and assigning over it. The dead draw no longer consumes entropy or leaves a junk entry in the choice sequence, which improves shrinking. Chained `override(...)` calls accumulate, and the most recent override of a field wins.
+- `hegel::run_all_tests()` now counts a test body that throws a value not derived from `std::exception` (e.g. `throw 42;`) as a failure and continues the sweep, instead of letting the exception escape and terminate the process.
+- Every blob passed to `HEGEL_REPRODUCE_FAILURE` is now retained for bookkeeping (only the first is replayed, matching the other Hegel implementations, which the docs now state unambiguously), and registering a second `HEGEL_REPRODUCE_FAILURE` for the same test is a loud error instead of a silent no-op.
+- Documentation fixes: `hegel::test()` documents that a failing body's own exception is rethrown (not `std::runtime_error`); `filter()` documents its real semantics — three attempts per draw, then the whole test case is rejected as if by `assume(false)` — plus the advice to prefer construction over filtration; `randoms()`/`HegelRandom` docs now describe this library's two modes accurately, recommend true-random mode for `<random>` distributions, and warn that a default-mode `HegelRandom` must not outlive the test-case callback; `Verbosity::Quiet` describes what it actually suppresses; the README quickstart shows the example's real failing output.

--- a/include/hegel/core.h
+++ b/include/hegel/core.h
@@ -146,15 +146,20 @@ namespace hegel::generators {
          * Creates a Generator that only produces values satisfying the
          * predicate. The new Generator has the same type as this Generator.
          *
-         * So for example, if you want sorted lists of length N, you should
-         * generate sorted lists of length N, not generate random lists and
-         * filter by a predicate of 'length == N && is_sorted'. (Although the
-         * latter is logically correct, it would be a performance nightmare, so
-         * Hegel doesn't let you do it that way.)
+         * Each draw makes up to three attempts to generate a value that
+         * satisfies @p pred (rejected attempts are discarded so they don't
+         * pollute shrinking). If all three attempts fail, the *whole test
+         * case* is rejected — as if `tc.assume(false)` had been called — and
+         * the engine moves on to a fresh one. Rejected test cases don't count
+         * toward Settings::test_cases, and a predicate that rejects too often
+         * fails the HealthCheck::FilterTooMuch health check.
          *
-         * For example, if you want sorted lists of length N, you should
-         * generate lists of length N and sort them, not generate random lists
-         * and filter by a predicate of 'length == N && is_sorted'.
+         * This makes filter suitable only for predicates that accept most
+         * values. Prefer constructing the values you want over filtering
+         * out the ones you don't: for sorted lists of length N, generate
+         * lists of length N and sort them, rather than filtering arbitrary
+         * lists on `length == N && is_sorted` (which would reject almost
+         * everything).
          *
          * @code{.cpp}
          * auto even = integers<int>({.min_value = 0, .max_value = 100})

--- a/include/hegel/datetime.h
+++ b/include/hegel/datetime.h
@@ -27,8 +27,7 @@ namespace hegel {
          */
         std::string to_string() const {
             char buf[32];
-            std::snprintf(buf, sizeof(buf), "%04d-%02d-%02d", year, month,
-                          day);
+            std::snprintf(buf, sizeof(buf), "%04d-%02d-%02d", year, month, day);
             return buf;
         }
     };
@@ -78,8 +77,8 @@ namespace hegel {
          */
         std::string to_string() const {
             char buf[32];
-            std::snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%06d", hour,
-                          minute, second, microsecond);
+            std::snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%06d", hour, minute,
+                          second, microsecond);
             return buf;
         }
     };

--- a/include/hegel/datetime.h
+++ b/include/hegel/datetime.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <cstdio>
+#include <ostream>
+#include <string>
+#include <tuple>
+
+namespace hegel {
+
+    /**
+     * @brief A calendar date in the proleptic Gregorian calendar.
+     *
+     * Produced by @ref hegel::generators::dates "dates()" and as the date
+     * part of DateTime. Plain aggregate: construct one with
+     * `hegel::Date{2024, 2, 29}`.
+     */
+    struct Date {
+        int year;  ///< Year. Generated dates span [1, 9999].
+        int month; ///< Month of the year, in [1, 12].
+        int day;   ///< Day of the month, in [1, days-in-month].
+
+        /**
+         * @brief The ISO 8601 serialization (`YYYY-MM-DD`).
+         *
+         * The year is zero-padded to four digits, month and day to two, so
+         * every Date has exactly one serialization.
+         */
+        std::string to_string() const {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%04d-%02d-%02d", year, month,
+                          day);
+            return buf;
+        }
+    };
+
+    /// @name Date comparisons (chronological order)
+    /// @{
+    inline bool operator==(const Date& a, const Date& b) {
+        return std::tie(a.year, a.month, a.day) ==
+               std::tie(b.year, b.month, b.day);
+    }
+    inline bool operator!=(const Date& a, const Date& b) { return !(a == b); }
+    inline bool operator<(const Date& a, const Date& b) {
+        return std::tie(a.year, a.month, a.day) <
+               std::tie(b.year, b.month, b.day);
+    }
+    inline bool operator>(const Date& a, const Date& b) { return b < a; }
+    inline bool operator<=(const Date& a, const Date& b) { return !(b < a); }
+    inline bool operator>=(const Date& a, const Date& b) { return !(a < b); }
+    /// @}
+
+    /// @brief Prints Date::to_string().
+    inline std::ostream& operator<<(std::ostream& os, const Date& d) {
+        return os << d.to_string();
+    }
+
+    /**
+     * @brief A time of day with microsecond precision. No timezone; values
+     *        are naive.
+     *
+     * Produced by @ref hegel::generators::times "times()" and as the time
+     * part of DateTime. Plain aggregate: construct one with
+     * `hegel::Time{23, 59, 59, 999999}`.
+     */
+    struct Time {
+        int hour;        ///< Hour of the day, in [0, 23].
+        int minute;      ///< Minute of the hour, in [0, 59].
+        int second;      ///< Second of the minute, in [0, 59].
+        int microsecond; ///< Microsecond of the second, in [0, 999999].
+
+        /**
+         * @brief The ISO 8601 serialization (`HH:MM:SS.ffffff`).
+         *
+         * The fractional-seconds field is always present and zero-padded to
+         * six digits — including when `microsecond` is zero — so every Time
+         * has exactly one serialization. (This differs from Python's
+         * `isoformat()`, which drops the fractional part when it is zero.)
+         */
+        std::string to_string() const {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%06d", hour,
+                          minute, second, microsecond);
+            return buf;
+        }
+    };
+
+    /// @name Time comparisons (chronological order)
+    /// @{
+    inline bool operator==(const Time& a, const Time& b) {
+        return std::tie(a.hour, a.minute, a.second, a.microsecond) ==
+               std::tie(b.hour, b.minute, b.second, b.microsecond);
+    }
+    inline bool operator!=(const Time& a, const Time& b) { return !(a == b); }
+    inline bool operator<(const Time& a, const Time& b) {
+        return std::tie(a.hour, a.minute, a.second, a.microsecond) <
+               std::tie(b.hour, b.minute, b.second, b.microsecond);
+    }
+    inline bool operator>(const Time& a, const Time& b) { return b < a; }
+    inline bool operator<=(const Time& a, const Time& b) { return !(b < a); }
+    inline bool operator>=(const Time& a, const Time& b) { return !(a < b); }
+    /// @}
+
+    /// @brief Prints Time::to_string().
+    inline std::ostream& operator<<(std::ostream& os, const Time& t) {
+        return os << t.to_string();
+    }
+
+    /**
+     * @brief A naive datetime: a Date plus a Time, with no timezone.
+     *
+     * Produced by @ref hegel::generators::datetimes "datetimes()". Plain
+     * aggregate: construct one with
+     * `hegel::DateTime{{2024, 2, 29}, {12, 30, 0, 0}}`.
+     */
+    struct DateTime {
+        Date date; ///< The calendar date.
+        Time time; ///< The time of day.
+
+        /**
+         * @brief The ISO 8601 serialization
+         *        (`YYYY-MM-DDTHH:MM:SS.ffffff`).
+         *
+         * Combines Date::to_string() and Time::to_string() with the `T`
+         * separator, so the fractional-seconds field is always present and
+         * every DateTime has exactly one serialization.
+         */
+        std::string to_string() const {
+            return date.to_string() + "T" + time.to_string();
+        }
+    };
+
+    /// @name DateTime comparisons (chronological order)
+    /// @{
+    inline bool operator==(const DateTime& a, const DateTime& b) {
+        return a.date == b.date && a.time == b.time;
+    }
+    inline bool operator!=(const DateTime& a, const DateTime& b) {
+        return !(a == b);
+    }
+    inline bool operator<(const DateTime& a, const DateTime& b) {
+        if (a.date != b.date) {
+            return a.date < b.date;
+        }
+        return a.time < b.time;
+    }
+    inline bool operator>(const DateTime& a, const DateTime& b) {
+        return b < a;
+    }
+    inline bool operator<=(const DateTime& a, const DateTime& b) {
+        return !(b < a);
+    }
+    inline bool operator>=(const DateTime& a, const DateTime& b) {
+        return !(a < b);
+    }
+    /// @}
+
+    /// @brief Prints DateTime::to_string().
+    inline std::ostream& operator<<(std::ostream& os, const DateTime& dt) {
+        return os << dt.to_string();
+    }
+
+} // namespace hegel

--- a/include/hegel/datetime.h
+++ b/include/hegel/datetime.h
@@ -24,6 +24,8 @@ namespace hegel {
          *
          * The year is zero-padded to four digits, month and day to two, so
          * every Date has exactly one serialization.
+         *
+         * @return The date as a `YYYY-MM-DD` string
          */
         std::string to_string() const {
             char buf[32];
@@ -34,21 +36,49 @@ namespace hegel {
 
     /// @name Date comparisons (chronological order)
     /// @{
+
+    /// @brief Equality: all three fields match.
+    /// @param a Left-hand date
+    /// @param b Right-hand date
+    /// @return Whether @p a and @p b are the same date
     inline bool operator==(const Date& a, const Date& b) {
         return std::tie(a.year, a.month, a.day) ==
                std::tie(b.year, b.month, b.day);
     }
+    /// @brief Inequality: any field differs.
+    /// @param a Left-hand date
+    /// @param b Right-hand date
+    /// @return Whether @p a and @p b are different dates
     inline bool operator!=(const Date& a, const Date& b) { return !(a == b); }
+    /// @brief Chronological order.
+    /// @param a Left-hand date
+    /// @param b Right-hand date
+    /// @return Whether @p a is earlier than @p b
     inline bool operator<(const Date& a, const Date& b) {
         return std::tie(a.year, a.month, a.day) <
                std::tie(b.year, b.month, b.day);
     }
+    /// @brief Chronological order.
+    /// @param a Left-hand date
+    /// @param b Right-hand date
+    /// @return Whether @p a is later than @p b
     inline bool operator>(const Date& a, const Date& b) { return b < a; }
+    /// @brief Chronological order.
+    /// @param a Left-hand date
+    /// @param b Right-hand date
+    /// @return Whether @p a is no later than @p b
     inline bool operator<=(const Date& a, const Date& b) { return !(b < a); }
+    /// @brief Chronological order.
+    /// @param a Left-hand date
+    /// @param b Right-hand date
+    /// @return Whether @p a is no earlier than @p b
     inline bool operator>=(const Date& a, const Date& b) { return !(a < b); }
     /// @}
 
     /// @brief Prints Date::to_string().
+    /// @param os Stream to print to
+    /// @param d Date to print
+    /// @return @p os, for chaining
     inline std::ostream& operator<<(std::ostream& os, const Date& d) {
         return os << d.to_string();
     }
@@ -74,6 +104,8 @@ namespace hegel {
          * six digits — including when `microsecond` is zero — so every Time
          * has exactly one serialization. (This differs from Python's
          * `isoformat()`, which drops the fractional part when it is zero.)
+         *
+         * @return The time as an `HH:MM:SS.ffffff` string
          */
         std::string to_string() const {
             char buf[32];
@@ -85,21 +117,49 @@ namespace hegel {
 
     /// @name Time comparisons (chronological order)
     /// @{
+
+    /// @brief Equality: all four fields match.
+    /// @param a Left-hand time
+    /// @param b Right-hand time
+    /// @return Whether @p a and @p b are the same time
     inline bool operator==(const Time& a, const Time& b) {
         return std::tie(a.hour, a.minute, a.second, a.microsecond) ==
                std::tie(b.hour, b.minute, b.second, b.microsecond);
     }
+    /// @brief Inequality: any field differs.
+    /// @param a Left-hand time
+    /// @param b Right-hand time
+    /// @return Whether @p a and @p b are different times
     inline bool operator!=(const Time& a, const Time& b) { return !(a == b); }
+    /// @brief Chronological order.
+    /// @param a Left-hand time
+    /// @param b Right-hand time
+    /// @return Whether @p a is earlier than @p b
     inline bool operator<(const Time& a, const Time& b) {
         return std::tie(a.hour, a.minute, a.second, a.microsecond) <
                std::tie(b.hour, b.minute, b.second, b.microsecond);
     }
+    /// @brief Chronological order.
+    /// @param a Left-hand time
+    /// @param b Right-hand time
+    /// @return Whether @p a is later than @p b
     inline bool operator>(const Time& a, const Time& b) { return b < a; }
+    /// @brief Chronological order.
+    /// @param a Left-hand time
+    /// @param b Right-hand time
+    /// @return Whether @p a is no later than @p b
     inline bool operator<=(const Time& a, const Time& b) { return !(b < a); }
+    /// @brief Chronological order.
+    /// @param a Left-hand time
+    /// @param b Right-hand time
+    /// @return Whether @p a is no earlier than @p b
     inline bool operator>=(const Time& a, const Time& b) { return !(a < b); }
     /// @}
 
     /// @brief Prints Time::to_string().
+    /// @param os Stream to print to
+    /// @param t Time to print
+    /// @return @p os, for chaining
     inline std::ostream& operator<<(std::ostream& os, const Time& t) {
         return os << t.to_string();
     }
@@ -122,6 +182,8 @@ namespace hegel {
          * Combines Date::to_string() and Time::to_string() with the `T`
          * separator, so the fractional-seconds field is always present and
          * every DateTime has exactly one serialization.
+         *
+         * @return The datetime as a `YYYY-MM-DDTHH:MM:SS.ffffff` string
          */
         std::string to_string() const {
             return date.to_string() + "T" + time.to_string();
@@ -130,30 +192,58 @@ namespace hegel {
 
     /// @name DateTime comparisons (chronological order)
     /// @{
+
+    /// @brief Equality: date and time both match.
+    /// @param a Left-hand datetime
+    /// @param b Right-hand datetime
+    /// @return Whether @p a and @p b are the same datetime
     inline bool operator==(const DateTime& a, const DateTime& b) {
         return a.date == b.date && a.time == b.time;
     }
+    /// @brief Inequality: date or time differs.
+    /// @param a Left-hand datetime
+    /// @param b Right-hand datetime
+    /// @return Whether @p a and @p b are different datetimes
     inline bool operator!=(const DateTime& a, const DateTime& b) {
         return !(a == b);
     }
+    /// @brief Chronological order: by date, then by time.
+    /// @param a Left-hand datetime
+    /// @param b Right-hand datetime
+    /// @return Whether @p a is earlier than @p b
     inline bool operator<(const DateTime& a, const DateTime& b) {
         if (a.date != b.date) {
             return a.date < b.date;
         }
         return a.time < b.time;
     }
+    /// @brief Chronological order: by date, then by time.
+    /// @param a Left-hand datetime
+    /// @param b Right-hand datetime
+    /// @return Whether @p a is later than @p b
     inline bool operator>(const DateTime& a, const DateTime& b) {
         return b < a;
     }
+    /// @brief Chronological order: by date, then by time.
+    /// @param a Left-hand datetime
+    /// @param b Right-hand datetime
+    /// @return Whether @p a is no later than @p b
     inline bool operator<=(const DateTime& a, const DateTime& b) {
         return !(b < a);
     }
+    /// @brief Chronological order: by date, then by time.
+    /// @param a Left-hand datetime
+    /// @param b Right-hand datetime
+    /// @return Whether @p a is no earlier than @p b
     inline bool operator>=(const DateTime& a, const DateTime& b) {
         return !(a < b);
     }
     /// @}
 
     /// @brief Prints DateTime::to_string().
+    /// @param os Stream to print to
+    /// @param dt DateTime to print
+    /// @return @p os, for chaining
     inline std::ostream& operator<<(std::ostream& os, const DateTime& dt) {
         return os << dt.to_string();
     }

--- a/include/hegel/generators/default.h
+++ b/include/hegel/generators/default.h
@@ -236,27 +236,26 @@ namespace hegel::generators {
         template <typename T>
         Generator<T>
         derived_struct_generator(std::vector<FieldOverride<T>> overrides) {
-            return compose(
-                [overrides = std::move(overrides)](const TestCase& tc) -> T {
-                    T result{};
-                    auto view = rfl::to_view(result);
-                    view.apply([&](const auto& field) {
-                        using PtrType = typename std::remove_cvref_t<
-                            decltype(field)>::Type;
-                        using FieldType = std::remove_pointer_t<PtrType>;
-                        // Later overrides shadow earlier ones for the same
-                        // field, so search newest-first.
-                        for (auto it = overrides.rbegin();
-                             it != overrides.rend(); ++it) {
-                            if (it->apply(result, field.value(), tc)) {
-                                return;
-                            }
+            return compose([overrides =
+                                std::move(overrides)](const TestCase& tc) -> T {
+                T result{};
+                auto view = rfl::to_view(result);
+                view.apply([&](const auto& field) {
+                    using PtrType =
+                        typename std::remove_cvref_t<decltype(field)>::Type;
+                    using FieldType = std::remove_pointer_t<PtrType>;
+                    // Later overrides shadow earlier ones for the same
+                    // field, so search newest-first.
+                    for (auto it = overrides.rbegin(); it != overrides.rend();
+                         ++it) {
+                        if (it->apply(result, field.value(), tc)) {
+                            return;
                         }
-                        *field.value() =
-                            default_generator<FieldType>().do_draw(tc);
-                    });
-                    return result;
+                    }
+                    *field.value() = default_generator<FieldType>().do_draw(tc);
                 });
+                return result;
+            });
         }
 
     } // namespace detail

--- a/include/hegel/generators/default.h
+++ b/include/hegel/generators/default.h
@@ -7,6 +7,7 @@
 // library can be consumed from C++17.
 #if HEGEL_HAS_REFLECTION
 
+#include <functional>
 #include <map>
 #include <optional>
 #include <set>
@@ -200,6 +201,64 @@ namespace hegel::generators {
             }
         };
 
+        // =================================================================
+        // Per-field overrides for DerivedGenerator::override()
+        // =================================================================
+
+        // Type-erased per-field override. apply() returns true — after
+        // drawing the replacement value directly into the object — iff this
+        // override targets the field at field_addr within obj.
+        template <typename T> struct FieldOverride {
+            std::function<bool(T& obj, const void* field_addr,
+                               const TestCase& tc)>
+                apply;
+        };
+
+        template <typename T, typename FieldSpec>
+        FieldOverride<T> make_field_override(FieldSpec spec) {
+            return FieldOverride<T>{[spec = std::move(spec)](
+                                        T& obj, const void* field_addr,
+                                        const TestCase& tc) {
+                if (static_cast<const void*>(&(obj.*FieldSpec::member_ptr)) !=
+                    field_addr) {
+                    return false;
+                }
+                obj.*FieldSpec::member_ptr = spec.generator.do_draw(tc);
+                return true;
+            }};
+        }
+
+        // Struct generator that draws every field in declaration order,
+        // consulting the overrides first: an overridden field draws only
+        // from its override generator — the default draw is skipped
+        // entirely, so it consumes no entropy and adds nothing to the
+        // choice sequence.
+        template <typename T>
+        Generator<T>
+        derived_struct_generator(std::vector<FieldOverride<T>> overrides) {
+            return compose(
+                [overrides = std::move(overrides)](const TestCase& tc) -> T {
+                    T result{};
+                    auto view = rfl::to_view(result);
+                    view.apply([&](const auto& field) {
+                        using PtrType = typename std::remove_cvref_t<
+                            decltype(field)>::Type;
+                        using FieldType = std::remove_pointer_t<PtrType>;
+                        // Later overrides shadow earlier ones for the same
+                        // field, so search newest-first.
+                        for (auto it = overrides.rbegin();
+                             it != overrides.rend(); ++it) {
+                            if (it->apply(result, field.value(), tc)) {
+                                return;
+                            }
+                        }
+                        *field.value() =
+                            default_generator<FieldType>().do_draw(tc);
+                    });
+                    return result;
+                });
+        }
+
     } // namespace detail
     /// @endcond
 
@@ -231,8 +290,15 @@ namespace hegel::generators {
          * @brief Override default per-field generators.
          *
          * Each field specification (from `field<&T::member>(gen)`) replaces
-         * the default generator for that member. Other fields keep the
-         * defaults from default_generator<T>().
+         * the default generator for that member: the overridden member is
+         * drawn only from the supplied generator, and the default draw is
+         * skipped entirely (it consumes no entropy and adds nothing to the
+         * choice sequence, so shrinking is unaffected). Other fields keep
+         * the defaults from default_generator<T>().
+         *
+         * Chained override() calls accumulate. If the same field is
+         * overridden more than once, the most recent override wins and is
+         * the only one drawn from.
          *
          * @code{.cpp}
          * auto gen = default_generator<Person>()
@@ -246,22 +312,21 @@ namespace hegel::generators {
          */
         template <typename... Fields>
         DerivedGenerator<T> override(Fields... fields) const {
-            Generator<T> base = *this;
-            auto fields_tuple = std::make_tuple(std::move(fields)...);
-            return DerivedGenerator<T>(
-                compose([base, fields_tuple](const TestCase& tc) mutable -> T {
-                    T result = base.do_draw(tc);
-                    std::apply(
-                        [&result, &tc](auto&... fs) {
-                            ((result.*(std::remove_reference_t<
-                                          decltype(fs)>::member_ptr) =
-                                  fs.generator.do_draw(tc)),
-                             ...);
-                        },
-                        fields_tuple);
-                    return result;
-                }));
+            std::vector<detail::FieldOverride<T>> overrides = overrides_;
+            (overrides.push_back(
+                 detail::make_field_override<T>(std::move(fields))),
+             ...);
+            DerivedGenerator<T> result(
+                detail::derived_struct_generator<T>(overrides));
+            result.overrides_ = std::move(overrides);
+            return result;
         }
+
+      private:
+        // The overrides this generator was built with, carried so chained
+        // override() calls extend the set instead of stacking draws on top
+        // of a fully drawn base.
+        std::vector<detail::FieldOverride<T>> overrides_;
     };
 
     /**

--- a/include/hegel/generators/formats.h
+++ b/include/hegel/generators/formats.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "hegel/core.h"
+#include "hegel/datetime.h"
 
 namespace hegel::generators {
 
@@ -88,37 +89,46 @@ namespace hegel::generators {
     /**
      * @brief Generate calendar dates.
      *
-     * Generates a date between January 01, 0001 through December 31, 9999 in
-     * the proleptic Gregorian calendar) and returns the ISO 8601 serialization
-     * (`YYYY-MM-DD`). Values shrink towards January 1st, 2000.
+     * Generates a hegel::Date between January 01, 0001 and December 31, 9999
+     * in the proleptic Gregorian calendar. Values shrink towards January 1st,
+     * 2000.
      *
-     * @return Generator producing ISO 8601 date strings.
+     * For the ISO 8601 string form (`YYYY-MM-DD`), call Date::to_string() on
+     * the drawn value, or map the generator:
+     * `dates().map([](hegel::Date d) { return d.to_string(); })`.
+     *
+     * @return Generator producing hegel::Date values.
      */
-    Generator<std::string> dates();
+    Generator<Date> dates();
 
     /**
      * @brief Generate times of day.
      *
-     * Generates a time between 00:00:00 and 23:59:59.999999 and returns the
-     * ISO 8601 serialization (`HH:MM:SS[.ffffff]`). Values shrink towards
-     * midnight. No timezone component is requested; generated values are naive.
+     * Generates a hegel::Time between 00:00:00 and 23:59:59.999999. Values
+     * shrink towards midnight. No timezone component is requested; generated
+     * values are naive.
      *
-     * @return Generator producing ISO 8601 time strings.
+     * For the ISO 8601 string form (`HH:MM:SS.ffffff`, fractional seconds
+     * always present), call Time::to_string() on the drawn value.
+     *
+     * @return Generator producing hegel::Time values.
      */
-    Generator<std::string> times();
+    Generator<Time> times();
 
     /**
      * @brief Generate datetimes.
      *
-     * Generates datetimes between January 01, 0001 at 00:00:00 and December 31,
-     * 9999 at 23:59:59.999999 and returns the ISO 8601 serialization
-     * (`YYYY-MM-DDTHH:MM:SS[.ffffff]`).
-     * No timezone is requested; generated values are naive. Examples from this
-     * strategy shrink towards midnight on January 1st 2000.
+     * Generates a hegel::DateTime between January 01, 0001 at 00:00:00 and
+     * December 31, 9999 at 23:59:59.999999. No timezone is requested;
+     * generated values are naive. Values shrink towards midnight on January
+     * 1st, 2000.
      *
-     * @return Generator producing ISO 8601 datetime strings.
+     * For the ISO 8601 string form (`YYYY-MM-DDTHH:MM:SS.ffffff`, fractional
+     * seconds always present), call DateTime::to_string() on the drawn value.
+     *
+     * @return Generator producing hegel::DateTime values.
      */
-    Generator<std::string> datetimes();
+    Generator<DateTime> datetimes();
 
     /// @}
 

--- a/include/hegel/generators/random.h
+++ b/include/hegel/generators/random.h
@@ -14,28 +14,41 @@ namespace hegel::generators {
      */
     struct RandomsParams {
         bool use_true_random =
-            false; ///< If true, use a local PRNG seed by Hegel instead of
-                   ///< per-value Hypothesis requests. Use this mode when the
-                   ///< cost of routing every draw through Hypothesis would be
-                   ///< too expensive. Values produced in true-random mode
-                   ///< cannot be shrunk.
+            false; ///< If false (the default), every `operator()` call is an
+                   ///< engine draw: the values become part of the test case's
+                   ///< choice sequence, so Hegel can steer them toward
+                   ///< interesting cases and shrink them on failure. If true,
+                   ///< Hegel draws a single seed and the values come from a
+                   ///< local `std::mt19937` seeded with it: reproducible via
+                   ///< the seed, but the individual values are not shrunk.
+                   ///< Use true-random mode when passing the engine to
+                   ///< `<random>` distributions or when your code relies on
+                   ///< the outputs being uniformly distributed.
     };
 
     /**
-     * @brief A random engine that integrates with Hypothesis via Hegel.
+     * @brief A random engine whose output Hegel controls.
      *
-     * Satisfies the C++ UniformRandomBitGenerator named requirement, so it
-     * can be used with any `<random>` distribution.
+     * Produced by randoms(); see it for how to choose between the two modes.
+     * Satisfies the C++ UniformRandomBitGenerator named requirement.
+     *
+     * @warning **Lifetime:** in the default (test-case-backed) mode a
+     * HegelRandom holds a pointer to the TestCase it was drawn from, which is
+     * only valid while the test-case callback is running. Do not store one in
+     * a global, a member, or anything else that outlives the callback — calls
+     * after the callback returns are use-after-free. (True-random mode is
+     * self-contained and has no such constraint.)
      *
      * @code{.cpp}
+     *  // Default mode: each call is a shrinkable engine draw.
      *  auto rng = tc.draw(gs::randoms());
-     *  std::uniform_real_distribution<double> dist(0.0, 10.0);
-     *  double uniform_value = dist(rng);
+     *  uint32_t bits = rng();
      *
-     *  // Using true random
-     *  auto rng = tc.draw(gs::randoms({ .use_true_random = true }));
+     *  // True-random mode: a seeded local PRNG, e.g. for <random>
+     *  // distributions.
+     *  auto rng2 = tc.draw(gs::randoms({.use_true_random = true}));
      *  std::lognormal_distribution<double> dist(0.0, 10.0);
-     *  double uniform_value = dist(rng);
+     *  double value = dist(rng2);
      * @endcode
      */
     class HegelRandom {
@@ -44,12 +57,14 @@ namespace hegel::generators {
         using result_type = uint32_t;
 
         /**
-         * @brief Construct in artificial (Hegel-backed) mode.
+         * @brief Construct in the default (test-case-backed) mode.
          *
-         * Each call to `operator()` draws entropy from Hegel via the
-         * given test-case data, so the resulting values can be shrunken.
+         * Each call to `operator()` draws a `uint32_t` from the engine
+         * through @p tc, so the values join the choice sequence and can be
+         * shrunk.
          *
-         * @param data The active test case's data stream (non-owning).
+         * @param tc The active test case (non-owning). The constructed
+         *           HegelRandom must not outlive the test-case callback.
          */
         explicit HegelRandom(const TestCase& tc);
 
@@ -57,7 +72,8 @@ namespace hegel::generators {
          * @brief Construct in true-random mode using a seeded local PRNG.
          *
          * Values are produced by an internal `std::mt19937` seeded with
-         * @p seed. Values produced in true-random mode cannot be shrunk.
+         * @p seed; they do not touch the engine, so they are reproducible
+         * from the seed but not individually shrunk.
          *
          * @param seed Seed for the internal Mersenne Twister engine.
          */
@@ -86,26 +102,35 @@ namespace hegel::generators {
     /**
      * @brief Generate random number generators.
      *
-     * Returns a Generator that produces HegelRandom instances satisfying
-     * UniformRandomBitGenerator, enabling use with any `<random>` distribution.
-     * If use_true_random is set to true then values will be drawn from their
-     * usual distribution, seeded by Hegel. Otherwise they will actually be
-     * Hegel generated values (and will be shrunk accordingly for any failing
-     * test case). Setting use_true_random=false will tend to expose bugs that
-     * would occur with very low probability when it is set to true, and this
-     * flag should only be set to true when your code relies on the distribution
-     * of values for correctness.
+     * Returns a Generator producing HegelRandom instances, for testing code
+     * that takes a UniformRandomBitGenerator as input. There are two modes:
      *
-     * @note Some distributions from \<random\> do not interact well
-     * with Hegel controlling their randomness, and will behave in unpredictable
-     * ways, such as causing the program to hang. We recommend using true
-     * randoms on RNG instances that you expect to be passed to distributions
-     * from \<random\>.
+     * - **Default** (`use_true_random = false`): every call to the returned
+     *   engine's `operator()` is an engine draw. The values are part of the
+     *   test case's choice sequence, so Hegel steers them toward interesting
+     *   cases and shrinks them when the test fails. Prefer this mode when the
+     *   code under test consumes the 32-bit outputs directly — it tends to
+     *   find bugs that uniformly random values would hit only with very low
+     *   probability.
+     * - **True-random** (`use_true_random = true`): Hegel draws one seed and
+     *   the engine expands it with a local `std::mt19937`. Runs are
+     *   reproducible via the seed, but the individual values are not shrunk.
      *
+     * If you pass the engine to a `<random>` distribution
+     * (`std::uniform_real_distribution`, `std::lognormal_distribution`, ...),
+     * use true-random mode. Distributions expect uniform bits and consume a
+     * variable number of them; feeding them Hegel's engine-controlled (and,
+     * during shrinking, deliberately non-uniform) draws distorts their output
+     * and can make rejection-sampling loops behave pathologically, up to
+     * hanging. Also use true-random mode whenever your code relies on the
+     * distribution of the values for correctness.
+     *
+     * @warning In the default mode the drawn HegelRandom must not outlive the
+     * test-case callback; see HegelRandom for the lifetime rules.
      *
      * @code{.cpp}
      * namespace gs = hegel::generators;
-     * auto rng = tc.draw(gs::randoms());
+     * auto rng = tc.draw(gs::randoms({.use_true_random = true}));
      *
      * std::lognormal_distribution<double> dist(0.0, 1.0);
      * double value = dist(rng);

--- a/include/hegel/hegel.h
+++ b/include/hegel/hegel.h
@@ -332,7 +332,10 @@ namespace hegel {
     /**
      * @brief Run every test defined with @ref HEGEL_TEST in this binary.
      *
-     * Each test runs with its inline settings.
+     * Each test runs with its inline settings. Every failure is caught and
+     * reported to stderr — including test bodies that throw values not
+     * derived from std::exception — so one failing test never stops the
+     * sweep or the process.
      *
      * @code{.cpp}
      * int main() {

--- a/include/hegel/hegel.h
+++ b/include/hegel/hegel.h
@@ -308,9 +308,21 @@ namespace hegel {
      *                assumptions, and record notes.
      * @param settings Configuration settings (test count, debug mode, etc.)
      * @param failure_blobs The base64 blobs encoding the engine choices that
-     led to failures. Multiple blobs can be passed in for bookkeeping, but only
-     the first one is run.
-     * @throws std::runtime_error if any test case fails
+     *                      led to failures. When non-empty, generation is
+     *                      skipped and **only the first blob is replayed** —
+     *                      this matches the other Hegel implementations, where
+     *                      stacked reproduce-failure annotations are
+     *                      first-wins. Any further blobs are carried for
+     *                      bookkeeping only and are never run.
+     * @throws The test body's own exception when a single failing example is
+     *         found: after shrinking, the failure is replayed and the
+     *         exception the body threw on the minimal example is rethrown
+     *         as-is.
+     * @throws std::runtime_error if the run itself fails (engine error,
+     *                            health-check failure, flaky test), if a
+     *                            failure blob does not reproduce an error, or
+     *                            if multiple distinct failures are reported
+     *                            (Settings::report_multiple_failures)
      * @see Settings for configuration settings
      */
     void test(const std::function<void(TestCase&)>& test_fn,
@@ -410,8 +422,14 @@ namespace hegel {
  * instead of generating new cases. Delete the annotation to return to a normal
  * run.
  *
- * At least one blob is required. Additional blobs are accepted for bookkeeping,
- * but only the first is replayed.
+ * At least one blob is required. Additional blobs may be listed to keep track
+ * of several failures, but **only the first is replayed** — the rest are
+ * bookkeeping, to be deleted one by one as the failures are fixed. This
+ * first-wins rule matches the other Hegel implementations.
+ *
+ * Each test may have at most one HEGEL_REPRODUCE_FAILURE annotation.
+ * Registering a second one for the same test is an error: the program
+ * terminates during static initialization with a message naming the test.
  *
  * @code{.cpp}
  * HEGEL_REPRODUCE_FAILURE(addition_commutes, "AAEAAAAACgEAAAAA")

--- a/include/hegel/settings.h
+++ b/include/hegel/settings.h
@@ -12,7 +12,9 @@ namespace hegel {
      * @brief Verbosity levels.
      */
     enum class Verbosity {
-        Quiet,   ///< Minimal output (used by TUI)
+        Quiet,   ///< Suppress Hegel's diagnostic output: no notes or drawn
+                 ///< values on the failing replay, and no failure headers or
+                 ///< reproduction blobs. Failures still throw as usual.
         Normal,  ///< Default - standard test output
         Verbose, ///< More detailed output
         Debug    ///< Maximum verbosity + engine-side shrinker tracing

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -181,48 +181,37 @@ namespace hegel::generators {
             }
         };
 
-        /// ISO 8601 `YYYY-MM-DD`.
-        std::string format_date(const hegel_date_t& d) {
-            char buf[16];
-            std::snprintf(buf, sizeof(buf), "%04d-%02u-%02u",
-                          static_cast<int>(d.year), d.month, d.day);
-            return buf;
+        // Widen the engine's packed field types into the public structs.
+        Date to_date(const hegel_date_t& d) {
+            return Date{static_cast<int>(d.year), static_cast<int>(d.month),
+                        static_cast<int>(d.day)};
         }
 
-        /// ISO 8601 `HH:MM:SS[.ffffff]` — the fractional part is present
-        /// iff the microsecond is nonzero, matching `isoformat()`.
-        std::string format_time(const hegel_time_t& t) {
-            char buf[24];
-            if (t.microsecond != 0) {
-                std::snprintf(buf, sizeof(buf), "%02u:%02u:%02u.%06u", t.hour,
-                              t.minute, t.second,
-                              static_cast<unsigned>(t.microsecond));
-            } else {
-                std::snprintf(buf, sizeof(buf), "%02u:%02u:%02u", t.hour,
-                              t.minute, t.second);
-            }
-            return buf;
+        Time to_time(const hegel_time_t& t) {
+            return Time{static_cast<int>(t.hour), static_cast<int>(t.minute),
+                        static_cast<int>(t.second),
+                        static_cast<int>(t.microsecond)};
         }
 
-        class DatesGenerator : public IGenerator<std::string> {
+        class DatesGenerator : public IGenerator<Date> {
           public:
-            std::string do_draw(const TestCase& tc) const override {
-                return format_date(impl::draw_date(tc));
+            Date do_draw(const TestCase& tc) const override {
+                return to_date(impl::draw_date(tc));
             }
         };
 
-        class TimesGenerator : public IGenerator<std::string> {
+        class TimesGenerator : public IGenerator<Time> {
           public:
-            std::string do_draw(const TestCase& tc) const override {
-                return format_time(impl::draw_time(tc));
+            Time do_draw(const TestCase& tc) const override {
+                return to_time(impl::draw_time(tc));
             }
         };
 
-        class DatetimesGenerator : public IGenerator<std::string> {
+        class DatetimesGenerator : public IGenerator<DateTime> {
           public:
-            std::string do_draw(const TestCase& tc) const override {
+            DateTime do_draw(const TestCase& tc) const override {
                 hegel_datetime_t dt = impl::draw_datetime(tc);
-                return format_date(dt.date) + "T" + format_time(dt.time);
+                return DateTime{to_date(dt.date), to_time(dt.time)};
             }
         };
 
@@ -296,16 +285,12 @@ namespace hegel::generators {
              Generator<std::string>(new IpGenerator(6))});
     }
 
-    Generator<std::string> dates() {
-        return Generator<std::string>(new DatesGenerator());
-    }
+    Generator<Date> dates() { return Generator<Date>(new DatesGenerator()); }
 
-    Generator<std::string> times() {
-        return Generator<std::string>(new TimesGenerator());
-    }
+    Generator<Time> times() { return Generator<Time>(new TimesGenerator()); }
 
-    Generator<std::string> datetimes() {
-        return Generator<std::string>(new DatetimesGenerator());
+    Generator<DateTime> datetimes() {
+        return Generator<DateTime>(new DatetimesGenerator());
     }
 
     HegelRandom::HegelRandom(const TestCase& tc)

--- a/src/generators.cpp
+++ b/src/generators.cpp
@@ -1,4 +1,5 @@
 #include <hegel/core.h>
+#include <hegel/datetime.h>
 #include <hegel/generators/combinators.h>
 #include <hegel/generators/formats.h>
 #include <hegel/generators/numeric.h>

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -465,6 +465,21 @@ namespace hegel {
                 failed++;
                 std::fprintf(stderr, "[ FAILED ] %s\n%s\n", test.name,
                              e.what());
+            } catch (...) {
+                // hegel::test rethrows the failing body's own exception,
+                // which need not derive from std::exception. Count it as a
+                // failure like any other instead of letting it escape and
+                // terminate the process.
+                failed++;
+                std::string origin = "unknown exception type";
+                if (const std::type_info* tinfo =
+                        abi::__cxa_current_exception_type()) {
+                    origin = demangle(tinfo->name());
+                }
+                std::fprintf(stderr,
+                             "[ FAILED ] %s\ntest threw a non-standard "
+                             "exception of type %s\n",
+                             test.name, origin.c_str());
             }
         }
         std::fprintf(stderr, "Ran %zu Hegel tests: %zu failed\n",

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -415,8 +415,9 @@ namespace hegel {
                 return registry;
             }
 
-            std::map<std::string, std::string>& blob_registry() {
-                static std::map<std::string, std::string> registry;
+            std::map<std::string, std::vector<std::string>>& blob_registry() {
+                static std::map<std::string, std::vector<std::string>>
+                    registry;
                 return registry;
             }
         } // namespace
@@ -427,7 +428,21 @@ namespace hegel {
         }
 
         bool register_blob(const char* name, std::vector<const char*> blobs) {
-            blob_registry().insert({name, blobs.front()});
+            auto [it, inserted] = blob_registry().insert(
+                {name, std::vector<std::string>(blobs.begin(), blobs.end())});
+            if (!inserted) {
+                // Registration runs during static initialization, so this
+                // throw terminates the program — loudly, with this message —
+                // rather than silently dropping the new blobs.
+                throw std::logic_error(
+                    std::string("duplicate HEGEL_REPRODUCE_FAILURE "
+                                "registration for test '") +
+                    name +
+                    "': each test may have at most one "
+                    "HEGEL_REPRODUCE_FAILURE annotation. To track several "
+                    "blobs, list them all in that one annotation (only the "
+                    "first is replayed).");
+            }
             return true;
         }
 
@@ -436,7 +451,7 @@ namespace hegel {
             if (blob == blob_registry().end()) {
                 return {};
             }
-            return {blob->second};
+            return blob->second;
         }
     } // namespace internal
 

--- a/src/hegel.cpp
+++ b/src/hegel.cpp
@@ -416,8 +416,7 @@ namespace hegel {
             }
 
             std::map<std::string, std::vector<std::string>>& blob_registry() {
-                static std::map<std::string, std::vector<std::string>>
-                    registry;
+                static std::map<std::string, std::vector<std::string>> registry;
                 return registry;
             }
         } // namespace

--- a/tests/test_derived.cpp
+++ b/tests/test_derived.cpp
@@ -164,6 +164,62 @@ TEST(DefaultGeneratorProperty, PartialOverride) {
     });
 }
 
+// override() must SKIP the default draw for overridden fields, not draw the
+// default and assign over it. Observable through the Verbose draw trace:
+// every engine draw logs one "Generated:" line, so drawing Person with
+// `name` overridden by a draw-free just() must log exactly one line (the
+// remaining `age` int). The old draw-then-overwrite behavior logged two —
+// the dead default draw for `name` still consumed entropy and choices.
+TEST(DefaultGeneratorProperty, OverrideSkipsDefaultDraw) {
+    testing::internal::CaptureStderr();
+    hegel::test(
+        [](hegel::TestCase& tc) {
+            auto gen = gs::default_generator<Person>().override(
+                gs::field<&Person::name>(gs::just(std::string("fixed"))));
+            Person p = tc.draw(gen);
+            EXPECT_EQ(p.name, "fixed");
+        },
+        hegel::Settings{.test_cases = 1,
+                        .verbosity = hegel::Verbosity::Verbose,
+                        .derandomize = true,
+                        .database = hegel::Database::disabled()});
+    std::string log = testing::internal::GetCapturedStderr();
+
+    size_t draws = 0;
+    for (size_t pos = log.find("Generated:"); pos != std::string::npos;
+         pos = log.find("Generated:", pos + 1)) {
+        draws++;
+    }
+    EXPECT_EQ(draws, 1u)
+        << "expected exactly one engine draw (the non-overridden age "
+           "field); the overridden field's default draw must be skipped. "
+           "Draw trace:\n"
+        << log;
+}
+
+// Chained override() calls accumulate instead of stacking draws.
+TEST(DefaultGeneratorProperty, ChainedOverridesAccumulate) {
+    hegel::test([](hegel::TestCase& tc) {
+        auto gen = gs::default_generator<Point>()
+                       .override(gs::field<&Point::x>(gs::just(1.0)))
+                       .override(gs::field<&Point::y>(gs::just(2.0)));
+        Point p = tc.draw(gen);
+        EXPECT_EQ(p.x, 1.0);
+        EXPECT_EQ(p.y, 2.0);
+    });
+}
+
+// Overriding the same field again replaces the earlier override.
+TEST(DefaultGeneratorProperty, LastOverrideOfSameFieldWins) {
+    hegel::test([](hegel::TestCase& tc) {
+        auto gen = gs::default_generator<Point>()
+                       .override(gs::field<&Point::x>(gs::just(1.0)))
+                       .override(gs::field<&Point::x>(gs::just(3.0)));
+        Point p = tc.draw(gen);
+        EXPECT_EQ(p.x, 3.0);
+    });
+}
+
 TEST(DefaultGeneratorProperty, VectorOfStructs) {
     hegel::test([](hegel::TestCase& tc) {
         auto vec = tc.draw(gs::vectors(gs::default_generator<Point>(),

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -215,7 +215,8 @@ TEST(Datetime, StreamInsertionMatchesToString) {
 TEST(Datetime, DrawnValuesSerializeToCanonicalShape) {
     const std::regex date_re(R"(^\d{4}-\d{2}-\d{2}$)");
     const std::regex time_re(R"(^\d{2}:\d{2}:\d{2}\.\d{6}$)");
-    const std::regex datetime_re(R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$)");
+    const std::regex datetime_re(
+        R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$)");
     hegel::test(
         [&](hegel::TestCase& tc) {
             std::string d = tc.draw(gs::dates()).to_string();

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <regex>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -118,6 +119,144 @@ TEST(Formats, RegexFullmatchFalseAllowsContains) {
         hegel::Settings{.test_cases = 100,
                         .database = hegel::Database::disabled()});
     EXPECT_TRUE(saw_padding);
+}
+
+// =============================================================================
+// Typed date/time generators
+// =============================================================================
+
+// dates() produces structured hegel::Date values whose fields stay within
+// the documented generation range.
+TEST(Datetime, DatesProduceTypedValuesInRange) {
+    hegel::test(
+        [](hegel::TestCase& tc) {
+            hegel::Date d = tc.draw(gs::dates());
+            EXPECT_GE(d.year, 1);
+            EXPECT_LE(d.year, 9999);
+            EXPECT_GE(d.month, 1);
+            EXPECT_LE(d.month, 12);
+            EXPECT_GE(d.day, 1);
+            EXPECT_LE(d.day, 31);
+        },
+        hegel::Settings{.test_cases = 100,
+                        .database = hegel::Database::disabled()});
+}
+
+// times() produces structured hegel::Time values with in-range fields.
+TEST(Datetime, TimesProduceTypedValuesInRange) {
+    hegel::test(
+        [](hegel::TestCase& tc) {
+            hegel::Time t = tc.draw(gs::times());
+            EXPECT_GE(t.hour, 0);
+            EXPECT_LE(t.hour, 23);
+            EXPECT_GE(t.minute, 0);
+            EXPECT_LE(t.minute, 59);
+            EXPECT_GE(t.second, 0);
+            EXPECT_LE(t.second, 59);
+            EXPECT_GE(t.microsecond, 0);
+            EXPECT_LE(t.microsecond, 999999);
+        },
+        hegel::Settings{.test_cases = 100,
+                        .database = hegel::Database::disabled()});
+}
+
+// datetimes() produces a hegel::DateTime combining both structures.
+TEST(Datetime, DatetimesProduceTypedValuesInRange) {
+    hegel::test(
+        [](hegel::TestCase& tc) {
+            hegel::DateTime dt = tc.draw(gs::datetimes());
+            EXPECT_GE(dt.date.year, 1);
+            EXPECT_LE(dt.date.year, 9999);
+            EXPECT_GE(dt.date.month, 1);
+            EXPECT_LE(dt.date.month, 12);
+            EXPECT_GE(dt.date.day, 1);
+            EXPECT_LE(dt.date.day, 31);
+            EXPECT_GE(dt.time.hour, 0);
+            EXPECT_LE(dt.time.hour, 23);
+            EXPECT_GE(dt.time.minute, 0);
+            EXPECT_LE(dt.time.minute, 59);
+            EXPECT_GE(dt.time.second, 0);
+            EXPECT_LE(dt.time.second, 59);
+            EXPECT_GE(dt.time.microsecond, 0);
+            EXPECT_LE(dt.time.microsecond, 999999);
+        },
+        hegel::Settings{.test_cases = 100,
+                        .database = hegel::Database::disabled()});
+}
+
+// to_string produces the canonical ISO 8601 shape: dates are YYYY-MM-DD and
+// times always carry a six-digit fractional-seconds field, including at
+// microsecond == 0, so every value has exactly one serialization.
+TEST(Datetime, ToStringIsCanonicalIso8601) {
+    hegel::Date d{2000, 1, 2};
+    EXPECT_EQ(d.to_string(), "2000-01-02");
+
+    hegel::Time midnight{0, 0, 0, 0};
+    EXPECT_EQ(midnight.to_string(), "00:00:00.000000");
+
+    hegel::Time t{23, 59, 59, 999999};
+    EXPECT_EQ(t.to_string(), "23:59:59.999999");
+
+    hegel::DateTime dt{{1999, 12, 31}, {1, 2, 3, 42}};
+    EXPECT_EQ(dt.to_string(), "1999-12-31T01:02:03.000042");
+}
+
+// operator<< prints the same canonical serialization as to_string().
+TEST(Datetime, StreamInsertionMatchesToString) {
+    std::ostringstream out;
+    out << hegel::Date{2024, 2, 29} << " " << hegel::Time{12, 30, 0, 0} << " "
+        << hegel::DateTime{{2024, 2, 29}, {12, 30, 0, 7}};
+    EXPECT_EQ(out.str(),
+              "2024-02-29 12:30:00.000000 2024-02-29T12:30:00.000007");
+}
+
+// Every drawn value round-trips through to_string() into the single
+// canonical shape (fixed-width fields, fractional seconds always present).
+TEST(Datetime, DrawnValuesSerializeToCanonicalShape) {
+    const std::regex date_re(R"(^\d{4}-\d{2}-\d{2}$)");
+    const std::regex time_re(R"(^\d{2}:\d{2}:\d{2}\.\d{6}$)");
+    const std::regex datetime_re(R"(^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$)");
+    hegel::test(
+        [&](hegel::TestCase& tc) {
+            std::string d = tc.draw(gs::dates()).to_string();
+            EXPECT_TRUE(std::regex_match(d, date_re)) << d;
+            std::string t = tc.draw(gs::times()).to_string();
+            EXPECT_TRUE(std::regex_match(t, time_re)) << t;
+            std::string dt = tc.draw(gs::datetimes()).to_string();
+            EXPECT_TRUE(std::regex_match(dt, datetime_re)) << dt;
+        },
+        hegel::Settings{.test_cases = 100,
+                        .database = hegel::Database::disabled()});
+}
+
+// The comparison operators order values chronologically, field by field.
+TEST(Datetime, ComparisonOperators) {
+    hegel::Date d1{2000, 1, 2};
+    hegel::Date d2{2000, 2, 1};
+    EXPECT_TRUE(d1 == d1);
+    EXPECT_TRUE(d1 != d2);
+    EXPECT_TRUE(d1 < d2);
+    EXPECT_TRUE(d1 <= d1);
+    EXPECT_TRUE(d2 > d1);
+    EXPECT_TRUE(d2 >= d2);
+
+    hegel::Time t1{6, 0, 0, 999999};
+    hegel::Time t2{6, 0, 1, 0};
+    EXPECT_TRUE(t1 == t1);
+    EXPECT_TRUE(t1 != t2);
+    EXPECT_TRUE(t1 < t2);
+    EXPECT_TRUE(t1 <= t2);
+    EXPECT_TRUE(t2 > t1);
+    EXPECT_TRUE(t2 >= t1);
+
+    hegel::DateTime dt1{{2000, 1, 1}, {23, 59, 59, 999999}};
+    hegel::DateTime dt2{{2000, 1, 2}, {0, 0, 0, 0}};
+    EXPECT_TRUE(dt1 == dt1);
+    EXPECT_TRUE(dt1 != dt2);
+    EXPECT_TRUE(dt1 < dt2);
+    EXPECT_TRUE(dt1 <= dt1);
+    EXPECT_TRUE(dt2 > dt1);
+    EXPECT_TRUE(dt2 >= dt2);
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_hegel.cpp
+++ b/tests/test_hegel.cpp
@@ -220,6 +220,28 @@ TEST(FailureBlobs, BlobReproduceFailure) {
     }
 }
 
+// Every blob given to HEGEL_REPRODUCE_FAILURE is kept in the registry (the
+// annotation above registers two), even though hegel::test replays only the
+// first. Losing the extras silently would defeat their bookkeeping purpose.
+TEST(FailureBlobs, RegistryKeepsAllBlobs) {
+    std::vector<std::string> blobs = hegel::internal::reproduce_blobs_for(
+        (std::string(__FILE__) + "::obvious_fail").c_str());
+    EXPECT_EQ(blobs,
+              (std::vector<std::string>{"AAEAAAAACgEAAAAA", "invalid"}));
+}
+
+// Registering a second HEGEL_REPRODUCE_FAILURE for the same test must be a
+// loud error, not a silent drop of the new blobs.
+TEST(FailureBlobs, DuplicateRegistrationThrows) {
+    const char* key = "test_hegel.cpp::duplicate_registration_probe";
+    EXPECT_TRUE(hegel::internal::register_blob(key, {"blob-one"}));
+    EXPECT_THROW(hegel::internal::register_blob(key, {"blob-two"}),
+                 std::logic_error);
+    // The original registration is untouched by the failed one.
+    EXPECT_EQ(hegel::internal::reproduce_blobs_for(key),
+              std::vector<std::string>{"blob-one"});
+}
+
 TEST(Settings, VerbosityToString) {
     using hegel::Verbosity;
     EXPECT_STREQ(hegel::verbosity_to_string(Verbosity::Quiet), "quiet");

--- a/tests/test_hegel.cpp
+++ b/tests/test_hegel.cpp
@@ -226,8 +226,7 @@ TEST(FailureBlobs, BlobReproduceFailure) {
 TEST(FailureBlobs, RegistryKeepsAllBlobs) {
     std::vector<std::string> blobs = hegel::internal::reproduce_blobs_for(
         (std::string(__FILE__) + "::obvious_fail").c_str());
-    EXPECT_EQ(blobs,
-              (std::vector<std::string>{"AAEAAAAACgEAAAAA", "invalid"}));
+    EXPECT_EQ(blobs, (std::vector<std::string>{"AAEAAAAACgEAAAAA", "invalid"}));
 }
 
 // Registering a second HEGEL_REPRODUCE_FAILURE for the same test must be a

--- a/tests/test_run_all.cpp
+++ b/tests/test_run_all.cpp
@@ -1,6 +1,8 @@
-// Standalone check for hegel::run_all_tests(): both HEGEL_TESTs below must
-// run (the failure must not stop the sweep), and the return value must
-// report the failure. Exits 0 on success.
+// Standalone check for hegel::run_all_tests(): every HEGEL_TEST below must
+// run (the failures must not stop the sweep), and the return value must
+// report the failures. A test body that throws a value that is not a
+// std::exception (here: an int) must be counted as a failure like any other,
+// not escape and kill the process. Exits 0 on success.
 
 #include <cstdio>
 #include <hegel/hegel.h>
@@ -14,6 +16,12 @@ HEGEL_TEST(always_fails,
            {.database = hegel::Database::disabled()})(hegel::TestCase& tc) {
     tc.draw(gs::integers<int>());
     throw std::runtime_error("always fails");
+}
+
+HEGEL_TEST(throws_non_std_exception,
+           {.database = hegel::Database::disabled()})(hegel::TestCase& tc) {
+    tc.draw(gs::integers<int>());
+    throw 42; // not derived from std::exception
 }
 
 HEGEL_TEST(always_passes,


### PR DESCRIPTION
<details>
<summary>Implementation details (AI-generated)</summary>

Fixes from a documentation-vs-behavior audit of the public API:

- New `hegel/datetime.h` with typed `hegel::Date`/`Time`/`DateTime`; the temporal generators return these instead of strings (zerover, breaking change). C++17-clean, with six-digit fractional-second formatting matching hegel-rust.
- `filter()` docs describe the real semantics: three attempts per draw, then the test case is rejected (not "retries until satisfied").
- Registering two `HEGEL_REPRODUCE_FAILURE` handlers for the same test now throws instead of silently ignoring the second; first-wins replay behavior is kept and documented.
- `run_all_tests` no longer aborts on a non-`std::exception` throw — it is caught and counted as a failure like any other.
- `randoms()` docs rewritten to describe what it actually is (engine-backed PRNG draws, replayable), with a prominent lifetime warning; the previous description of a Hypothesis-style wire protocol was fiction.
- `override()` on derived generators genuinely skips the overridden fields' default draws (verified by draw-trace counting) instead of drawing and discarding.

Verification: 322/322 ctest, the C++17 consumer compile check, and format check pass. clang-tidy and doxygen jobs were not runnable in the audit environment — CI should confirm those two.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
